### PR TITLE
tsimulation pre-release fixes: validation, guards, wiring, collectors, packaging

### DIFF
--- a/packages/tsimulation/CHANGELOG.md
+++ b/packages/tsimulation/CHANGELOG.md
@@ -7,6 +7,35 @@ onward. Before 1.0, minor versions may include breaking changes.
 
 ## [Unreleased]
 
+### Changed (behavior)
+- The engine now runs each module's `validate()` at load time, throwing on
+  invalid params and warning on warnings. Previously `validate()` was never
+  called by the engine — a module relying on it for enforcement would have let
+  invalid params through.
+- A transform whose key equals a module output name is now a wiring error
+  (previously the transform silently shadowed the output for consumers). Rename
+  the transform, or drop it if it only passed the output through.
+- Lag `delay` must be an integer ≥ 1; invalid delays are now a wiring error
+  instead of silently producing `undefined`/mis-sized buffers.
+
+### Fixed
+- The NaN/Infinity output guard now descends into array outputs and nesting
+  deeper than 3 levels (was silently skipping both).
+- `topologicalSort` no longer mutates its input graph, so it is safe to call
+  more than once (a second call previously returned wrong order).
+- `ComponentParams.get()` deep-clones object subtrees (immutability); `set()`
+  no longer throws when a path passes through a `null` node.
+- Collector `max`/`min`/`peak` return `undefined` (not `±Infinity`) on an empty
+  or all-non-numeric series; `max`/`min` use a reduce (no stack overflow on long
+  series). `collectResults` validates metric configs up front (unknown source
+  key, or neither source nor transform, now throw).
+
+### Packaging
+- Added a `default` export condition so `require('tsimulation')` resolves on
+  Node with `require(esm)` support; documented the package as ESM-only.
+- Ship `src/` so the bundled source maps / declaration maps resolve to real
+  sources for debugging and go-to-definition.
+
 ## [0.1.0] — 2026-07-18
 
 Initial public release. Extracted, unchanged in behavior, from the

--- a/packages/tsimulation/README.md
+++ b/packages/tsimulation/README.md
@@ -28,6 +28,11 @@ npm install tsimulation
 
 Requires Node.js ≥ 20 (or any ESM runtime with `structuredClone`).
 
+**ESM-only.** This package ships as ES modules — `import` it. There is no
+CommonJS build; `require('tsimulation')` works only on Node versions with
+`require(esm)` support (≥ 20.19 / ≥ 22.12) and throws `ERR_REQUIRE_ESM` on
+older ones. Use a dynamic `import()` from CommonJS if you need to.
+
 ## Concepts
 
 | Concept | What it is |

--- a/packages/tsimulation/package.json
+++ b/packages/tsimulation/package.json
@@ -28,13 +28,15 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
+    "src",
     "README.md",
     "LICENSE",
     "CHANGELOG.md"

--- a/packages/tsimulation/src/autowire.ts
+++ b/packages/tsimulation/src/autowire.ts
@@ -215,28 +215,36 @@ export function buildDependencyGraph(
  */
 export function topologicalSort(graph: Map<string, DepNode>): AnyModule[] {
   const sorted: AnyModule[] = [];
-  const remaining = new Map(graph);
+
+  // Work on a private copy of each node's dependency set. `new Map(graph)` would
+  // be a shallow copy that shares the DepNode Sets, so mutating them below would
+  // corrupt the caller's graph — this function is exported and must be safe to
+  // call more than once on the same graph. `providesTo` is only read.
+  const pending = new Map<string, Set<string>>();
+  for (const [name, node] of graph) {
+    pending.set(name, new Set(node.dependsOn));
+  }
 
   // Find nodes with no dependencies
   const ready: string[] = [];
-  for (const [name, node] of remaining) {
-    if (node.dependsOn.size === 0) {
+  for (const [name, deps] of pending) {
+    if (deps.size === 0) {
       ready.push(name);
     }
   }
 
   while (ready.length > 0) {
     const name = ready.shift()!;
-    const node = remaining.get(name)!;
+    const node = graph.get(name)!;
     sorted.push(node.module);
-    remaining.delete(name);
+    pending.delete(name);
 
-    // Remove this node from dependencies of others
+    // Remove this node from the pending dependencies of others
     for (const dependent of node.providesTo) {
-      if (remaining.has(dependent)) {
-        const depNode = remaining.get(dependent)!;
-        depNode.dependsOn.delete(name);
-        if (depNode.dependsOn.size === 0) {
+      const deps = pending.get(dependent);
+      if (deps) {
+        deps.delete(name);
+        if (deps.size === 0) {
           ready.push(dependent);
         }
       }
@@ -244,8 +252,8 @@ export function topologicalSort(graph: Map<string, DepNode>): AnyModule[] {
   }
 
   // Check for cycles
-  if (remaining.size > 0) {
-    const cycleNodes = Array.from(remaining.keys()).join(', ');
+  if (pending.size > 0) {
+    const cycleNodes = Array.from(pending.keys()).join(', ');
     throw new Error(
       `Dependency cycle detected involving: ${cycleNodes}. ` +
       `Use 'lags' configuration to break the cycle.`

--- a/packages/tsimulation/src/autowire.ts
+++ b/packages/tsimulation/src/autowire.ts
@@ -316,8 +316,9 @@ export function validateConnectorTypes(
 
 /**
  * Validate all wiring at composition time.
- * Catches typos in dependsOn, missing lag sources, transform chaining,
- * and modules that directly consume cycle-breaker transforms.
+ * Catches transform/output name collisions, typos in dependsOn, missing or
+ * invalid lag sources/delays, transform chaining, and modules that directly
+ * consume cycle-breaker transforms.
  */
 export function validateWiring(
   modules: AnyModule[],
@@ -334,6 +335,25 @@ export function validateWiring(
     Object.entries(transforms).filter(([, entry]) => entry !== undefined)
   );
 
+  // A transform must not reuse a module output's name. If it did, a module
+  // consuming that name would silently receive the transform's value (module
+  // inputs resolve transforms before outputs) while dependsOn/lag sources
+  // resolve to the module output — the two paths disagree. Identity
+  // pass-throughs are simply redundant: a same-named input already resolves to
+  // the output natively.
+  for (const name of Object.keys(definedTransforms)) {
+    const provider = outputRegistry.get(name);
+    if (provider) {
+      errors.push(
+        `Transform '${name}' collides with output '${name}' provided by module '${provider}'. ` +
+        `Rename the transform, or drop it if it only passes the output through.`
+      );
+      // Drop it so the passes below reason over a clean transform set (a name
+      // here is now guaranteed to be a pure transform, not a shadowed output).
+      delete definedTransforms[name];
+    }
+  }
+
   // All available output names (module outputs + transform names)
   const allOutputs = new Set([...outputRegistry.keys(), ...Object.keys(definedTransforms)]);
 
@@ -342,15 +362,14 @@ export function validateWiring(
   // ordering edge for them (buildDependencyGraph resolves deps through the
   // output registry only) and transform values are never written to
   // currentOutputs, so a chained transform would silently read undefined.
+  // (Colliding transform names were dropped above, so a dep still found in
+  // definedTransforms is necessarily a pure transform name.)
   for (const [name, entry] of Object.entries(definedTransforms)) {
     const config = normalizeTransform(entry);
     for (const dep of config.dependsOn) {
       if (!allOutputs.has(dep)) {
         errors.push(`Transform '${name}' depends on '${dep}' which doesn't exist`);
-      } else if (definedTransforms[dep] !== undefined && !outputRegistry.has(dep)) {
-        // A dep that is both a transform name and a module output resolves
-        // to the module output (transforms read module outputs only), so
-        // only pure transform names are chaining errors.
+      } else if (definedTransforms[dep] !== undefined) {
         errors.push(
           `Transform '${name}' depends on transform '${dep}'. ` +
           `Transform chaining is not supported — depend on module outputs instead.`
@@ -359,10 +378,13 @@ export function validateWiring(
     }
   }
 
-  // Check lag sources exist
+  // Check lag sources exist and delays are valid
   for (const [name, lag] of Object.entries(lags)) {
     if (!allOutputs.has(lag.source)) {
       errors.push(`Lag '${name}' reads source '${lag.source}' which doesn't exist`);
+    }
+    if (!Number.isInteger(lag.delay) || lag.delay < 1) {
+      errors.push(`Lag '${name}' has delay ${lag.delay}: delay must be an integer >= 1`);
     }
   }
 

--- a/packages/tsimulation/src/autowire.ts
+++ b/packages/tsimulation/src/autowire.ts
@@ -395,14 +395,23 @@ export function validateWiring(
 // =============================================================================
 
 /**
- * Recursively check a value for NaN/Infinity up to a depth limit.
- * Covers Record<Region, number>, Record<Mineral, {demand, cumulative}>, etc.
+ * Recursively check a value for NaN/Infinity.
+ * Descends into both plain objects (Record<Region, number>,
+ * Record<Mineral, {demand, cumulative}>) and arrays (number[] time series,
+ * arrays of records). The depth cap is a runaway/cyclic-structure guard, not a
+ * semantic limit — set well beyond any realistic output nesting.
  */
+const MAX_CHECK_DEPTH = 8;
 function checkNumeric(val: unknown, path: string, mod: string, year: number, depth = 0): void {
   if (typeof val === 'number' && (Number.isNaN(val) || !Number.isFinite(val))) {
     throw new Error(`Module '${mod}' output '${path}' is ${val} at year ${year}`);
   }
-  if (depth < 3 && typeof val === 'object' && val !== null && !Array.isArray(val)) {
+  if (depth >= MAX_CHECK_DEPTH || typeof val !== 'object' || val === null) return;
+  if (Array.isArray(val)) {
+    for (let i = 0; i < val.length; i++) {
+      checkNumeric(val[i], `${path}[${i}]`, mod, year, depth + 1);
+    }
+  } else {
     for (const [k, v] of Object.entries(val)) {
       checkNumeric(v, `${path}.${k}`, mod, year, depth + 1);
     }

--- a/packages/tsimulation/src/autowire.ts
+++ b/packages/tsimulation/src/autowire.ts
@@ -13,6 +13,7 @@
 
 import { Module, ConnectorType } from './module.js';
 import { Year, YearIndex } from './types.js';
+import { validatedMerge } from './validated-merge.js';
 
 // =============================================================================
 // TYPES
@@ -559,7 +560,15 @@ export function initAutowired(config: AutowireConfig): AutowireState {
   const paramsMap = new Map<string, any>();
 
   for (const mod of sortedModules) {
-    const mergedParams = mod.mergeParams(params[mod.name] ?? {});
+    // Merge + validate at load time: throws on invalid params, warns on
+    // warnings. This is what makes each Module's required validate() actually
+    // run — the engine's contract, not something consumers must wire by hand.
+    const mergedParams = validatedMerge(
+      mod.name,
+      (p) => mod.validate(p),
+      (p) => mod.mergeParams(p),
+      params[mod.name] ?? {}
+    );
     paramsMap.set(mod.name, mergedParams);
     stateMap.set(mod.name, mod.init(mergedParams));
   }

--- a/packages/tsimulation/src/collectors.ts
+++ b/packages/tsimulation/src/collectors.ts
@@ -53,10 +53,13 @@ export type MetricAggregator =
 /**
  * How to compute a summary metric from timeseries data.
  *
- * - source: timeseries field to aggregate (must match a timeseries 'as' or 'source')
+ * - source: the produced timeseries key to aggregate — a timeseries def's `as`
+ *   if it set one, otherwise its `source` (validated; an unknown key throws)
  * - as: name for the metric in output
  * - aggregator: how to reduce the timeseries to a single value
  * - transform: optional function over all year outputs (for multi-field metrics)
+ *
+ * Exactly one of `source` or `transform` must be set.
  */
 export interface MetricDef {
   source?: string;
@@ -118,6 +121,8 @@ export function resolveKey(def: TimeseriesDef): string {
 // AGGREGATION
 // =============================================================================
 
+const isNumber = (v: unknown): v is number => typeof v === 'number';
+
 /**
  * Aggregate a series of values into a metric.
  */
@@ -126,12 +131,14 @@ function aggregate(values: any[], years: number[], aggregator: MetricAggregator)
     return values[values.length - 1];
   }
 
-  if (aggregator === 'max') {
-    return Math.max(...values.filter(v => typeof v === 'number'));
-  }
-
-  if (aggregator === 'min') {
-    return Math.min(...values.filter(v => typeof v === 'number'));
+  if (aggregator === 'max' || aggregator === 'min') {
+    // Return undefined — not a silent -Infinity/Infinity — when there is no
+    // numeric value. Reduce (not Math.max(...spread)) also avoids a call-stack
+    // overflow when a generic series is very long.
+    const nums = values.filter(isNumber);
+    if (nums.length === 0) return undefined;
+    const pick = aggregator === 'max' ? Math.max : Math.min;
+    return nums.reduce((a, b) => pick(a, b));
   }
 
   if (typeof aggregator === 'object' && 'first' in aggregator) {
@@ -146,13 +153,17 @@ function aggregate(values: any[], years: number[], aggregator: MetricAggregator)
   if (typeof aggregator === 'object' && 'peak' in aggregator) {
     let maxVal = -Infinity;
     let maxYear = years[0];
+    let found = false;
     for (let i = 0; i < values.length; i++) {
-      if (typeof values[i] === 'number' && values[i] > maxVal) {
-        maxVal = values[i];
-        maxYear = years[i];
+      if (isNumber(values[i])) {
+        found = true;
+        if (values[i] > maxVal) {
+          maxVal = values[i];
+          maxYear = years[i];
+        }
       }
     }
-    return { value: maxVal, year: maxYear };
+    return found ? { value: maxVal, year: maxYear } : undefined;
   }
 
   if (typeof aggregator === 'object' && 'custom' in aggregator) {
@@ -171,9 +182,26 @@ function aggregate(values: any[], years: number[], aggregator: MetricAggregator)
  */
 export function collectResults(result: AutowireResult, config: CollectorConfig): CollectedResults {
   const { years } = result;
-  const timeseries: Record<string, any>[] = [];
+
+  // Validate metric configs before doing any work (fail fast, like
+  // validateWiring). Each metric needs exactly one of source/transform, and a
+  // `source` must name a *produced* timeseries key — the resolved name (`as` if
+  // the timeseries def set one, else its `source`), not the raw source.
+  const timeseriesKeys = new Set(config.timeseries.map(resolveKey));
+  for (const def of config.metrics) {
+    if (def.transform) continue;
+    if (!def.source) {
+      throw new Error(`Metric '${def.as}' has neither a 'source' nor a 'transform'`);
+    }
+    if (!timeseriesKeys.has(def.source)) {
+      const renamed = config.timeseries.find(t => t.source === def.source && t.as && t.as !== def.source);
+      const hint = renamed ? ` (a timeseries has source '${def.source}' but was renamed via as: '${renamed.as}')` : '';
+      throw new Error(`Metric '${def.as}' reads timeseries key '${def.source}' which no timeseries def produces${hint}`);
+    }
+  }
 
   // Collect timeseries per year
+  const timeseries: Record<string, any>[] = [];
   for (let i = 0; i < years.length; i++) {
     const outputs = getOutputsAtYear(result, i);
     const record: Record<string, any> = { year: years[i] };
@@ -186,9 +214,8 @@ export function collectResults(result: AutowireResult, config: CollectorConfig):
     timeseries.push(record);
   }
 
-  // Collect metrics
+  // Collect metrics (config validated above)
   const metrics: Record<string, any> = {};
-
   for (const def of config.metrics) {
     if (def.transform) {
       // Multi-field metric: compute per-year values then aggregate
@@ -198,8 +225,8 @@ export function collectResults(result: AutowireResult, config: CollectorConfig):
         values.push(def.transform(outputs, years[i], i));
       }
       metrics[def.as] = aggregate(values, years, def.aggregator);
-    } else if (def.source) {
-      // Single-field metric: extract from timeseries
+    } else {
+      // Single-field metric: extract from a produced timeseries key
       const values = timeseries.map(r => r[def.source!]);
       metrics[def.as] = aggregate(values, years, def.aggregator);
     }

--- a/packages/tsimulation/src/component-params.ts
+++ b/packages/tsimulation/src/component-params.ts
@@ -29,7 +29,9 @@ export class ComponentParams<T extends object = Record<string, unknown>> {
 
   /**
    * Get value at dot-path (e.g., 'climate.sensitivity').
-   * Returns undefined if path doesn't exist.
+   * Returns undefined if path doesn't exist. Object subtrees are returned as
+   * deep clones so the container stays immutable — mutating the result cannot
+   * change internal state. (Primitives copy by value already.)
    */
   get(path: string): unknown {
     const parts = path.split('.');
@@ -40,19 +42,23 @@ export class ComponentParams<T extends object = Record<string, unknown>> {
       }
       current = current[part];
     }
-    return current;
+    return current !== null && typeof current === 'object' ? structuredClone(current) : current;
   }
 
   /**
    * Returns a new ComponentParams with the value at path replaced.
-   * Does not mutate the original.
+   * Does not mutate the original. Missing intermediate nodes — including `null`
+   * ones — are created as empty objects; a primitive sitting on the path is
+   * likewise overwritten with an object to make room for the deeper key.
    */
   set(path: string, value: unknown): ComponentParams<T> {
     const parts = path.split('.');
     const clone = structuredClone(this.data);
     let current: any = clone;
     for (let i = 0; i < parts.length - 1; i++) {
-      if (current[parts[i]] === undefined || typeof current[parts[i]] !== 'object') {
+      // `== null` catches both undefined and null (typeof null === 'object',
+      // so the type check alone would step into a null and then throw).
+      if (current[parts[i]] == null || typeof current[parts[i]] !== 'object') {
         current[parts[i]] = {};
       }
       current = current[parts[i]];

--- a/packages/tsimulation/test/collectors.test.ts
+++ b/packages/tsimulation/test/collectors.test.ts
@@ -94,6 +94,68 @@ test('metric aggregator: peak returns value and year', () => {
   assert.deepStrictEqual(metrics.peak, { value: 40, year: 2004 });
 });
 
+test('max/min return undefined (not ±Infinity) on an all-non-numeric series', () => {
+  const { metrics } = collectResults(run(), {
+    // path resolves to nothing → every value undefined
+    timeseries: [{ source: 'group', as: 'empty', path: 'nope.nope' }],
+    metrics: [
+      { source: 'empty', as: 'hi', aggregator: 'max' },
+      { source: 'empty', as: 'lo', aggregator: 'min' },
+      { source: 'empty', as: 'pk', aggregator: { peak: true } },
+    ],
+  });
+  assert.strictEqual(metrics.hi, undefined);
+  assert.strictEqual(metrics.lo, undefined);
+  assert.strictEqual(metrics.pk, undefined);
+});
+
+test('a metric whose source is not a produced timeseries key throws', () => {
+  assert.throws(
+    () =>
+      collectResults(run(), {
+        timeseries: [{ source: 'level' }],
+        metrics: [{ source: 'ghost', as: 'x', aggregator: 'last' }],
+      }),
+    /Metric 'x' reads timeseries key 'ghost' which no timeseries def produces/
+  );
+});
+
+test('a metric referencing a renamed source gets a helpful hint', () => {
+  assert.throws(
+    () =>
+      collectResults(run(), {
+        timeseries: [{ source: 'level', as: 'renamed' }],
+        metrics: [{ source: 'level', as: 'x', aggregator: 'last' }],
+      }),
+    /renamed via as: 'renamed'/
+  );
+});
+
+test('a metric with neither source nor transform throws', () => {
+  assert.throws(
+    () =>
+      collectResults(run(), {
+        timeseries: [{ source: 'level' }],
+        metrics: [{ as: 'ghost', aggregator: 'last' }],
+      }),
+    /Metric 'ghost' has neither a 'source' nor a 'transform'/
+  );
+});
+
+test('max reduces without a stack overflow on a long series', () => {
+  const N = 200000;
+  const big = {
+    years: Array.from({ length: N }, (_, i) => i),
+    outputs: { m: { v: Array.from({ length: N }, (_, i) => i) } },
+    states: { m: [] as any[] },
+  };
+  const { metrics } = collectResults(big, {
+    timeseries: [{ source: 'v' }],
+    metrics: [{ source: 'v', as: 'hi', aggregator: 'max' }],
+  });
+  assert.strictEqual(metrics.hi, N - 1);
+});
+
 test('metric aggregator: custom, and a transform-based metric', () => {
   const { metrics } = collectResults(run(), {
     timeseries: [{ source: 'level' }],

--- a/packages/tsimulation/test/component-params.test.ts
+++ b/packages/tsimulation/test/component-params.test.ts
@@ -39,6 +39,22 @@ test('entries and paths walk numeric leaves only', () => {
   assert.deepStrictEqual(p.paths().sort(), ['a.b', 'c']);
 });
 
+test('set() through a null intermediate node does not throw', () => {
+  const p = ComponentParams.from({ a: { b: null } });
+  const q = p.set('a.b.c', 5);
+  assert.strictEqual(q.get('a.b.c'), 5);
+  // top-level null too
+  const r = ComponentParams.from<{ a: unknown }>({ a: null }).set('a.x', 9);
+  assert.strictEqual(r.get('a.x'), 9);
+});
+
+test('get() of an object subtree does not alias internal state', () => {
+  const p = ComponentParams.from({ g: { x: 1 } });
+  const sub = p.get('g') as { x: number };
+  sub.x = 999; // mutating the returned subtree must not leak back
+  assert.strictEqual(p.get('g.x'), 1);
+});
+
 test('toParams returns a deep clone that does not alias internal state', () => {
   const src = { a: { b: 1 } };
   const p = ComponentParams.from(src);

--- a/packages/tsimulation/test/output-guard.test.ts
+++ b/packages/tsimulation/test/output-guard.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for the NaN/Infinity output guard's coverage of arrays and deep nesting.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { runAutowired } from '../src/autowire.js';
+import { defineModule } from '../src/module.js';
+import { okValidate, throwsWith } from './helpers.js';
+
+/** Module that emits a single output value `v`. */
+const emit = (v: unknown) =>
+  defineModule({
+    name: 'emit',
+    description: 'emits one output',
+    defaults: {},
+    inputs: [] as const,
+    outputs: ['v'] as const,
+    validate: okValidate,
+    mergeParams: (p) => p,
+    init: () => ({}),
+    step: () => ({ state: {}, outputs: { v } }),
+  });
+
+const run = (v: unknown) => runAutowired({ modules: [emit(v)], startYear: 0, endYear: 0 });
+
+test('NaN inside an array output is caught, with an indexed path', () => {
+  throwsWith(() => run([1, NaN, 3]), "output 'v[1]' is NaN at year 0");
+});
+
+test('Infinity inside an array output is caught', () => {
+  throwsWith(() => run([1, 2, Infinity]), "output 'v[2]' is Infinity at year 0");
+});
+
+test('NaN inside an array of records is caught (mixed path)', () => {
+  throwsWith(
+    () => run([{ x: 1 }, { x: NaN }]),
+    "output 'v[1].x' is NaN at year 0"
+  );
+});
+
+test('NaN nested in objects at depth 4 is caught (was silently skipped before)', () => {
+  throwsWith(
+    () => run({ a: { b: { c: { d: NaN } } } }),
+    "output 'v.a.b.c.d' is NaN at year 0"
+  );
+});
+
+test('a number at the depth cap (8) is still checked', () => {
+  // v.L1.L2.L3.L4.L5.L6.L7 = NaN  → NaN sits at depth 8
+  const atCap = { L1: { L2: { L3: { L4: { L5: { L6: { L7: NaN } } } } } } };
+  throwsWith(() => run(atCap), 'is NaN at year 0');
+});
+
+test('NaN beyond the depth cap is intentionally not checked (runaway guard)', () => {
+  // NaN sits at depth 9, one past MAX_CHECK_DEPTH — documented as uncaught.
+  const tooDeep = { L1: { L2: { L3: { L4: { L5: { L6: { L7: { L8: { L9: NaN } } } } } } } } };
+  assert.doesNotThrow(() => run(tooDeep));
+});
+
+test('valid arrays and nested records pass the guard', () => {
+  const result = run({ series: [1, 2, 3], regions: [{ v: 4 }, { v: 5 }] });
+  assert.deepStrictEqual(result.outputs.emit.v[0], { series: [1, 2, 3], regions: [{ v: 4 }, { v: 5 }] });
+});

--- a/packages/tsimulation/test/topo-sort.test.ts
+++ b/packages/tsimulation/test/topo-sort.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Tests that topologicalSort does not mutate its input graph and is idempotent.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildOutputRegistry, buildDependencyGraph, topologicalSort } from '../src/autowire.js';
+import { defineModule } from '../src/module.js';
+import { okValidate } from './helpers.js';
+
+const A = defineModule({
+  name: 'A', description: '', defaults: {}, inputs: [] as const, outputs: ['a'] as const,
+  validate: okValidate, mergeParams: (p) => p, init: () => ({}),
+  step: () => ({ state: {}, outputs: { a: 1 } }),
+});
+const B = defineModule({
+  name: 'B', description: '', defaults: {}, inputs: ['a'] as const, outputs: ['b'] as const,
+  validate: okValidate, mergeParams: (p) => p, init: () => ({}),
+  step: (_s, i) => ({ state: {}, outputs: { b: i.a } }),
+});
+
+function freshGraph() {
+  const registry = buildOutputRegistry([B, A]); // B registered first, to make order non-trivial
+  return buildDependencyGraph([B, A], registry);
+}
+
+test('topologicalSort does not mutate the caller graph', () => {
+  const graph = freshGraph();
+  assert.deepStrictEqual([...graph.get('B')!.dependsOn], ['A']);
+  topologicalSort(graph);
+  // The caller's dependency sets must be intact after sorting.
+  assert.deepStrictEqual([...graph.get('B')!.dependsOn], ['A']);
+  assert.strictEqual(graph.get('A')!.dependsOn.size, 0);
+});
+
+test('topologicalSort is idempotent — same graph, same valid order', () => {
+  const graph = freshGraph();
+  const first = topologicalSort(graph).map((m) => m.name);
+  const second = topologicalSort(graph).map((m) => m.name);
+  assert.deepStrictEqual(first, ['A', 'B']); // dependency respected
+  assert.deepStrictEqual(second, first); // stable across calls
+});

--- a/packages/tsimulation/test/validation.test.ts
+++ b/packages/tsimulation/test/validation.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests that the engine runs each module's validate() at load time.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { runAutowired, initAutowired } from '../src/autowire.js';
+import { defineModule } from '../src/module.js';
+import { okValidate, throwsWith } from './helpers.js';
+
+/** A module whose validate() rejects when `x < 100`. */
+const guarded = defineModule({
+  name: 'guarded',
+  description: 'validates its params',
+  defaults: { x: 1 },
+  inputs: [] as const,
+  outputs: ['y'] as const,
+  validate: (p) => {
+    const x = (p as { x?: number }).x ?? 0;
+    return x >= 100
+      ? { valid: true, errors: [], warnings: [] }
+      : { valid: false, errors: [`x must be >= 100, got ${x}`], warnings: [] };
+  },
+  mergeParams: (p) => ({ x: 1, ...p }),
+  init: () => ({}),
+  step: () => ({ state: {}, outputs: { y: 42 } }),
+});
+
+test('runAutowired throws when a module validate() fails, naming the module and error', () => {
+  throwsWith(
+    () => runAutowired({ modules: [guarded], startYear: 0, endYear: 0 }),
+    '[guarded]'
+  );
+  throwsWith(
+    () => runAutowired({ modules: [guarded], startYear: 0, endYear: 0 }),
+    'x must be >= 100'
+  );
+});
+
+test('initAutowired (stepper path) validates too', () => {
+  throwsWith(() => initAutowired({ modules: [guarded], startYear: 0, endYear: 0 }), '[guarded]');
+});
+
+test('valid params (via override) pass validation and run', () => {
+  const result = runAutowired({
+    modules: [guarded],
+    params: { guarded: { x: 150 } },
+    startYear: 0,
+    endYear: 0,
+  });
+  assert.strictEqual(result.outputs.guarded.y[0], 42);
+});
+
+test('validate() warnings are surfaced via console.warn but do not throw', () => {
+  const warner = defineModule({
+    name: 'warner',
+    description: 'warns but is valid',
+    defaults: {},
+    inputs: [] as const,
+    outputs: ['z'] as const,
+    validate: () => ({ valid: true, errors: [], warnings: ['z is unusually high'] }),
+    mergeParams: (p) => p,
+    init: () => ({}),
+    step: () => ({ state: {}, outputs: { z: 1 } }),
+  });
+
+  const warnings: string[] = [];
+  const orig = console.warn;
+  console.warn = (msg: string) => {
+    warnings.push(msg);
+  };
+  try {
+    const result = runAutowired({ modules: [warner], startYear: 0, endYear: 0 });
+    assert.strictEqual(result.outputs.warner.z[0], 1);
+    assert.ok(warnings.some((w) => w.includes('z is unusually high')));
+    assert.ok(warnings.some((w) => w.includes('[warner]')));
+  } finally {
+    console.warn = orig;
+  }
+});
+
+test('a module with a passing validate() is unaffected', () => {
+  const plain = defineModule({
+    name: 'plain',
+    description: 'always valid',
+    defaults: {},
+    inputs: [] as const,
+    outputs: ['v'] as const,
+    validate: okValidate,
+    mergeParams: (p) => p,
+    init: () => ({}),
+    step: () => ({ state: {}, outputs: { v: 7 } }),
+  });
+  const result = runAutowired({ modules: [plain], startYear: 0, endYear: 0 });
+  assert.strictEqual(result.outputs.plain.v[0], 7);
+});

--- a/packages/tsimulation/test/wiring.test.ts
+++ b/packages/tsimulation/test/wiring.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for composition-time wiring validation: transform/output collisions
+ * and lag delay validation.
+ */
+
+import { test } from 'node:test';
+import { buildOutputRegistry, validateWiring, runAutowired } from '../src/autowire.js';
+import { defineModule } from '../src/module.js';
+import { okValidate, throwsWith } from './helpers.js';
+
+const producer = defineModule({
+  name: 'producer',
+  description: '',
+  defaults: {},
+  inputs: [] as const,
+  outputs: ['x'] as const,
+  validate: okValidate,
+  mergeParams: (p) => p,
+  init: () => ({}),
+  step: () => ({ state: {}, outputs: { x: 1 } }),
+});
+
+test('a transform whose name collides with a module output is rejected', () => {
+  const registry = buildOutputRegistry([producer]);
+  throwsWith(
+    () => validateWiring([producer], registry, { x: (o) => o.x }, {}),
+    "Transform 'x' collides with output 'x' provided by module 'producer'"
+  );
+});
+
+test('collision is caught through runAutowired (integration)', () => {
+  const consumer = defineModule({
+    name: 'consumer',
+    description: '',
+    defaults: {},
+    inputs: ['x'] as const,
+    outputs: ['y'] as const,
+    validate: okValidate,
+    mergeParams: (p) => p,
+    init: () => ({}),
+    step: (_s, i) => ({ state: {}, outputs: { y: i.x } }),
+  });
+  throwsWith(
+    () =>
+      runAutowired({
+        modules: [producer, consumer],
+        transforms: { x: { fn: (o) => (o.x ?? 0) * 2, dependsOn: [] } },
+        startYear: 0,
+        endYear: 0,
+      }),
+    'collides with output'
+  );
+});
+
+test('lag delay must be an integer >= 1', () => {
+  const registry = buildOutputRegistry([producer]);
+  for (const bad of [0, -1, 1.5]) {
+    throwsWith(
+      () => validateWiring([producer], registry, {}, { lagX: { source: 'x', delay: bad, initial: 0 } }),
+      `delay ${bad}: delay must be an integer >= 1`
+    );
+  }
+});
+
+test('lag delay of 1 and 2 are accepted', () => {
+  const registry = buildOutputRegistry([producer]);
+  // Should not throw.
+  validateWiring([producer], registry, {}, { lagX: { source: 'x', delay: 1, initial: 0 } });
+  validateWiring([producer], registry, {}, { lagX: { source: 'x', delay: 2, initial: 0 } });
+});

--- a/src/simulation-autowired.ts
+++ b/src/simulation-autowired.ts
@@ -67,24 +67,6 @@ function buildTransforms(mergedEnergyParams: any) {
       dependsOn: ['energyInvestment'],
     },
 
-    // Capital uses effectiveWorkers from demographics
-    effectiveWorkers: {
-      fn: (outputs: Record<string, any>) => outputs.effectiveWorkers,
-      dependsOn: ['effectiveWorkers'],
-    },
-
-    // Capital and demand use gdp from production
-    gdp: {
-      fn: (outputs: Record<string, any>) => outputs.gdp,
-      dependsOn: ['gdp'],
-    },
-
-    // Dispatch and energy use electricity demand from demand module
-    electricityDemand: {
-      fn: (outputs: Record<string, any>) => requireOutput(outputs, 'electricityDemand', 'electricityDemand'),
-      dependsOn: ['electricityDemand'],
-    },
-
     // Resources needs gdpPerCapita (derived)
     gdpPerCapita: {
       fn: (outputs: Record<string, any>) => {
@@ -127,18 +109,6 @@ function buildTransforms(mergedEnergyParams: any) {
       dependsOn: [],
     },
 
-    // Dispatch needs capacities from energy
-    capacities: {
-      fn: (outputs: Record<string, any>) => outputs.capacities,
-      dependsOn: ['capacities'],
-    },
-
-    // Resources needs additions from energy
-    additions: {
-      fn: (outputs: Record<string, any>) => requireOutput(outputs, 'additions', 'additions'),
-      dependsOn: ['additions'],
-    },
-
     // Resources needs transport electrification for EV battery mineral demand
     transportElectrification: {
       fn: (outputs: Record<string, any>) => {
@@ -146,12 +116,6 @@ function buildTransforms(mergedEnergyParams: any) {
         return sectors.transport?.electrificationRate ?? 0;
       },
       dependsOn: ['sectors'],
-    },
-
-    // Resources needs population from demographics
-    population: {
-      fn: (outputs: Record<string, any>) => outputs.population,
-      dependsOn: ['population'],
     },
 
     // Cycle-breaker: reads current-year dispatch+energy outputs that may not exist yet
@@ -238,24 +202,6 @@ function buildTransforms(mergedEnergyParams: any) {
       dependsOn: ['investment', 'regionalSavings'],
     },
 
-    // Regional capacities from energy module
-    regionalCapacities: {
-      fn: (outputs: Record<string, any>) => requireOutput(outputs, 'regionalCapacities', 'regionalCapacities'),
-      dependsOn: ['regionalCapacities'],
-    },
-
-    // Regional energy-project WACC from energy module
-    regionalWACC: {
-      fn: (outputs: Record<string, any>) => requireOutput(outputs, 'regionalWACC', 'regionalWACC'),
-      dependsOn: ['regionalWACC'],
-    },
-
-    // Long-duration storage regional capacities (GWh) from energy module
-    longStorageRegional: {
-      fn: (outputs: Record<string, any>) => requireOutput(outputs, 'longStorageRegional', 'longStorageRegional'),
-      dependsOn: ['longStorageRegional'],
-    },
-
     // Regional carbon prices from energy params
     regionalCarbonPrice: {
       fn: () => {
@@ -276,12 +222,6 @@ function buildTransforms(mergedEnergyParams: any) {
         optionalOutput<Record<string, number> | null>(outputs, 'capacities', null),
       ),
       dependsOn: [],
-    },
-
-    // Regional life expectancy for capital module retirement age adjustment
-    regionalLifeExpectancy: {
-      fn: (outputs: Record<string, any>) => outputs.regionalLifeExpectancy,
-      dependsOn: ['regionalLifeExpectancy'],
     },
 
     // Regional GDP for capital module intergenerational transfers


### PR DESCRIPTION
Fixes the 8 pre-release findings from the deep review of the `tsimulation` framework. Every finding was reproduced before fixing and confirmed fixed after (repro scripts + new tests). Each fix is its own commit, each preceded by a simplify pass.

## Fixes

**Correctness (framework)**
1. **Engine runs `validate()`** — `initAutowired` routes params through `validatedMerge`, so a module's required `validate()` actually runs (throw on invalid, warn on warnings). It was never called before; consumers had to enforce validation by hand.
2. **NaN/Infinity guard covers arrays + deep nesting** — `checkNumeric` now descends into array outputs (`series[1]`) and up to depth 8; non-finite numbers inside arrays or below depth 3 previously passed silently.
3. **`topologicalSort` non-destructive** — works on a private copy of each node's dependency set; a second call on the same graph no longer returns dependency-violating order.
4. **Transform/output name collisions rejected** — `validateWiring` errors when a transform key equals a module output (they resolved on different paths and disagreed). Paired with removing 10 vestigial identity pass-through transforms in the energy sim (provably bit-identical: baseline unchanged except its timestamp).
5. **`lag.delay` validated** — must be an integer ≥ 1; `delay: 0` previously yielded `undefined` at step 0 and never used `initial`.

**Correctness (supporting modules)**
6. **`ComponentParams` immutability** — `get()` deep-clones object subtrees; `set()` no longer throws when a path passes through a `null` node.
7. **Collectors hardening** — `max`/`min`/`peak` return `undefined` (not `±Infinity`) on empty/non-numeric series; `max`/`min` reduce (no stack overflow on long series); `collectResults` validates metric configs up front (unknown source key, or neither source nor transform, now throw with a rename hint).

**Packaging**
8. **`require()` resolves + maps ship** — added a `default` export condition (bare `require('tsimulation')` now works on Node with `require(esm)`); ship `src/` so the bundled source/declaration maps resolve; documented ESM-only.

## Two pre-1.0 API decisions deliberately NOT taken here
Left out because they are naming/DX judgment calls the maintainer should make, not bugs: the `Year`/`YearIndex`/`startYear` calendar vocabulary in a domain-independent API, and the uniformly-`any` result surface (`getOutputsAtYear`, `getTimeSeries`, `StepperResult.outputs`). Happy to follow up on either.

## Verification
- Framework: **85/85** (`node:test`), including ~25 new tests across validation, output-guard, topo-sort, wiring, component-params, collectors.
- Energy model + aging-places: full suite passes (416 checks); **regression within tolerance**; fix 4 confirmed byte-identical to the blessed baseline.
- `npm pack --dry-run`, `require`/`import` smoke tests, and `npm run example` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUkWGWVQt6wF6tD4BrRvNG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUkWGWVQt6wF6tD4BrRvNG)_