### PR TITLE
Scenario loader: validate nested override keys (catch dead/typo'd nested params)

### DIFF
--- a/src/scenario.ts
+++ b/src/scenario.ts
@@ -9,12 +9,42 @@ import { readFile } from 'fs/promises';
 import { SimulationParams } from './simulation.js';
 import { ALL_MODULES } from './simulation-autowired.js';
 
-/** Known param keys per module, for catching fat-fingered scenario keys.
- * Derived from each module's own defaults so it can never drift from the
- * modules themselves (a new param is covered automatically). */
-const MODULE_PARAM_KEYS: Record<string, Set<string>> = Object.fromEntries(
-  ALL_MODULES.map((m) => [m.name, new Set(Object.keys(m.defaults as object))]),
+/** Each module's default param object, keyed by module name. Used to validate
+ * scenario overrides against the real default SHAPE — recursively, so dead or
+ * fat-fingered NESTED keys are caught too (e.g. energy.sources.solar.growthRate,
+ * which the module's spread-merge would otherwise silently ignore — exactly the
+ * bug that let a dead growthRate sit in a dozen scenarios). Derived from the
+ * modules themselves so it can never drift. */
+const MODULE_DEFAULTS: Record<string, Record<string, unknown>> = Object.fromEntries(
+  ALL_MODULES.map((m) => [m.name, m.defaults as Record<string, unknown>]),
 );
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v != null && typeof v === 'object' && !Array.isArray(v);
+}
+
+/** Interface fields that are optional / `Partial<Record<...>>` — declared in a
+ * module's TS interface but not instantiated in its defaults object, so the
+ * defaults-shape walk can't see them. These are valid overrides (e.g. the
+ * per-region `maxGrowthRate`/`capacityFactor` policy overrides on
+ * RegionalEnergyParams), so we neither warn when they're absent from defaults
+ * nor recurse into their open key space. */
+const OPEN_PARTIAL_KEYS = new Set(['maxGrowthRate', 'capacityFactor']);
+
+/** Recursively warn about override keys absent from the default shape. Recurses
+ * only where BOTH sides are plain objects (records-of-records like sources /
+ * regional / sectors); stops at leaves, numeric maps, and open Partial records. */
+function validateOverrideKeys(override: unknown, defaults: unknown, path: string): void {
+  if (!isPlainObject(override) || !isPlainObject(defaults)) return;
+  for (const key of Object.keys(override)) {
+    if (OPEN_PARTIAL_KEYS.has(key)) continue;  // valid optional/Partial — don't warn or descend
+    if (!(key in defaults)) {
+      console.warn(`Warning: Unrecognized ${path} param "${key}" will be ignored`);
+      continue;
+    }
+    validateOverrideKeys(override[key], defaults[key], `${path}.${key}`);
+  }
+}
 
 // =============================================================================
 // TYPES
@@ -91,17 +121,14 @@ export function scenarioToParams(scenario: Scenario): SimulationParams {
       console.warn(`Warning: Unrecognized scenario key "${key}" will be ignored`);
       continue;
     }
-    // Validate inner param keys against the module's known params, so a
-    // fat-fingered override (energy: { carbonPriceTYPO: ... }) is flagged
-    // instead of silently dropped by the module's spread-based mergeParams.
-    const knownParams = MODULE_PARAM_KEYS[key];
+    // Validate override keys against the module's default shape — recursively,
+    // so a fat-fingered or dead NESTED override (energy.sources.solar.growthRate,
+    // energy: { carbonPriceTYPO: ... }) is flagged instead of silently dropped
+    // by the module's spread-based mergeParams.
+    const defaults = MODULE_DEFAULTS[key];
     const section = (scenario as unknown as Record<string, unknown>)[key];
-    if (knownParams && section && typeof section === 'object' && !Array.isArray(section)) {
-      for (const paramKey of Object.keys(section)) {
-        if (!knownParams.has(paramKey)) {
-          console.warn(`Warning: Unrecognized ${key} param "${paramKey}" will be ignored`);
-        }
-      }
+    if (defaults && isPlainObject(section)) {
+      validateOverrideKeys(section, defaults, key);
     }
   }
 

--- a/src/simulation.test.ts
+++ b/src/simulation.test.ts
@@ -43,6 +43,30 @@ test('scenarioToParams passes through startYear/endYear', () => {
   expect(params.endYear).toBe(2032);
 });
 
+test('scenarioToParams warns on dead NESTED keys but not on valid Partial optionals', () => {
+  const warnings: string[] = [];
+  const orig = console.warn;
+  console.warn = (m: string) => { warnings.push(m); };
+  try {
+    scenarioToParams({
+      name: 'Nested key validation', description: '',
+      // dead nested key (the sources.<x>.growthRate class) + a top-level typo
+      energy: {
+        sources: { solar: { growthRate: 0.3 } },
+        carbonPriceTYPO: 1,
+        // valid Partial optional absent from defaults — must NOT warn
+        regional: { oecd: { maxGrowthRate: { solar: 0.1 } } },
+      },
+    } as never);
+  } finally {
+    console.warn = orig;
+  }
+  const joined = warnings.join('\n');
+  expect(joined.includes('energy.sources.solar') && joined.includes('growthRate')).toBeTrue();
+  expect(joined.includes('carbonPriceTYPO')).toBeTrue();
+  expect(joined.includes('maxGrowthRate')).toBeFalse();  // valid optional, no false positive
+});
+
 test('2025 regional financing spreads reproduce the IEA-observed calibration', () => {
   // Total spread = static residual (energy defaults) + financingHomeBias ×
   // 2025 savings gap (capital outputs). The residuals were derived by hand


### PR DESCRIPTION
Root-cause fix for the class of bug that let a dead `sources.growthRate` sit in a dozen scenario files (removed in #36): **the scenario loader only validated override keys one level deep**. `energy.sources` is a known key, so it never looked inside `sources.solar.growthRate` — any dead or fat-fingered *nested* key was silently ignored by the module's spread-merge.

## Change

- Replaced the one-level key check with a **recursive walk over each module's default shape**, so nested dead/typo keys now warn (`Unrecognized energy.sources.solar param "growthRate" will be ignored`) instead of vanishing.
- `Partial`/optional interface fields absent from the defaults object (the per-region `maxGrowthRate`/`capacityFactor` policy overrides on `RegionalEnergyParams`) are allowlisted, so valid overrides like `regional-divergence`'s don't false-positive. The validator flagged that one on first run — correctly identified and handled.
- Added a test pinning both directions: it warns on a dead nested key + a top-level typo, and does **not** warn on the valid Partial optional.

## Why not re-point the scenarios' buildout speed instead

Context: the dead `sources.growthRate` was several scenarios' attempt to control renewable buildout speed. I tested re-pointing that intent at the live `maxGrowthRate` and it's the wrong fix — the lever is asymmetric: faster-intent scenarios (ssp1-19, test-singularity) are inert (economics already drives buildout below the cap), and slower-intent (central-path) only bites via an energy-starvation artifact (fossil can't backfill fast → GDP −18%, a spurious warming *drop*). So the #36 removal was the correct fix for the scenarios; this PR fixes the *enabler* so the class can't recur silently.

## Verification

`npx tsc --noEmit` clean; new test passes; full `npm test` green; `npm run regression` byte-identical across all 7 scenarios (validation-only, no behavior change); all scenario files load with zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNEmQrZPGGwVksKrmPmSum

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNEmQrZPGGwVksKrmPmSum)_