### PR TITLE
Anchor robot/datacenter ceilings to IFR/IEA data + store AI-robotics research

### DIFF
--- a/docs/SENSITIVITY.md
+++ b/docs/SENSITIVITY.md
@@ -14,6 +14,13 @@
 > the coupling — higher efficiency used to *destroy* GDP through an
 > uncoupled η ceiling) but did not remove it: with loop gain ≈ α+γ ≈ 0.8, any
 > growth-side residual is amplified ~5× into the level.
+>
+> **A co-equal second dial is `robotSaturation`** (the automation ceiling;
+> default 600/1,000 workers), which swings GDP 2100 ~1.6–2.2× over its plausible
+> range and is even *less* anchored — no fleet forecast supports it (see the
+> `robotSaturation` section below and `sources/ai-robotics-deployment-ceilings.md`).
+> The two together, not `serviceEfficiencyGrowth` alone, set the late-century
+> GDP band.
 
 The γ×damage grid below (a separate, smaller axis) identified two further
 consequential, least-constrained parameters:
@@ -136,3 +143,37 @@ Two honest takeaways:
 2. **Direction robust, terminal cost soft.** Report the transition shape without
    floor caveats, but treat the *terminal clean-energy price* as a band, biased
    toward the cheaper end. The default $12 is more likely too high than too low.
+
+## `robotSaturation`: a top GDP dial with no empirical anchor
+
+The robot-density ceiling (`demand.robotSaturation`, default **600 per 1,000
+workers**) is — with `serviceEfficiencyGrowth` — one of the two largest
+GDP-level dials in the model, and it is the *least* anchored. No humanoid/
+general-purpose fleet forecast survives scrutiny (see
+`sources/ai-robotics-deployment-ceilings.md`), and the default is **~600× today's
+global average robot density (~1/1,000 all workers) and ~35× Korea's current
+whole-economy frontier (~15/1,000 all workers)** — a humanoids-in-every-sector
+world, not manufacturing.
+
+Sweep (baseline):
+
+| `robotSaturation` | GDP 2100 | Gen 2100 (TWh) | WACC 2075 | Warming 2100 |
+|---|---|---|---|---|
+| 300 | 950 | 199,482 | 0.101 | 2.60 |
+| **600 (default)** | **1,151** | 250,952 | 0.109 | 2.62 |
+| 1,200 | 1,483 | 340,507 | 0.119 | 2.64 |
+| 2,400 | 2,047 | 503,786 | 0.127 | 2.67 |
+
+- **GDP 2100 swings ~1.6× across a defensible range (300→1,200)** and ~2.2× to
+  2,400 — a self-labeled speculative parameter with leverage comparable to the
+  sourced structural dials. The effect is almost entirely post-2050 (via the
+  robot labor-augmentation term), so it is specifically an end-of-century
+  phenomenon.
+- The rising WACC column shows the *economic* ceiling that should really bind:
+  more robots → more energy + capital demand → higher cost of capital (the
+  `ai-energy-boom` scenario self-limits at WACC ~15%). The hard `robotSaturation`
+  number is standing in for what should be an endogenous value-vs-cost limit.
+- **Report late-century GDP as explicitly conditional on `robotSaturation`**;
+  treat it as a wide band (~100–1,000), not a forecast. (The companion
+  `dataCenterSaturation` is GDP-neutral — a pure electricity sink — so it needs
+  no such GDP caveat; it matters only for the generation/emissions ledger.)

--- a/sources/ai-robotics-deployment-ceilings.md
+++ b/sources/ai-robotics-deployment-ceilings.md
@@ -1,0 +1,149 @@
+# AI Compute & Robotics: What Bounds Deployment Through 2050?
+
+Verified literature review (deep-research pass, 2026). Evidence base for the
+model's two automation ceilings — `robotSaturation` (robots per 1,000 workers)
+and `dataCenterSaturation` (AI/datacenter TWh/yr).
+
+Provenance: 23 sources; 22 of 25 extracted claims survived 3-vote adversarial
+verification (3 refuted, noted). **Coverage is deliberately asymmetric** — the
+AI-energy evidence is strong and current; the robotics-fleet and
+value-vs-cost evidence is thin or refuted. Confidence markers throughout.
+
+---
+
+## Headline
+
+The ceiling on AI-compute and robotics is a **supply / economic** question, not
+a demand-saturation one — but the credible forecast range is enormous (AI
+datacenter energy forecasts for 2030 diverge **~40×**). The demand-side
+*pull* (aging → automation → capital deepening) is the best-supported part of
+the picture; the "feed themselves" cost-vs-value ceiling is intuitive but
+**unconfirmed** (its one testable claim was refuted).
+
+---
+
+## 1. AI / datacenter energy — well-anchored
+
+- **2024 baseline: ~415 TWh (~1.5% of global electricity)** (IEA *Energy and
+  AI*, 2025). US is the measured leading indicator: **176 TWh in 2023 (4.4% of
+  US electricity)**, up from ~60 TWh flat in 2014–2016, CAGR accelerating
+  7%→18% (LBNL 2024). *(high)*
+- **2030: IEA Base Case ~945 TWh (~3%)**; **2035: IEA scenario range
+  700–1,700 TWh**. *(high)*
+- **But 2030 forecasts diverge ~40× (200 to ~8,000 TWh)** and GW-capacity
+  forecasts >13× (RAND ~327 GW vs Goldman ~24 GW vs McKinsey ~90 GW). The
+  divergence turns on **whether exponential chip-supply-led growth persists** —
+  a supply/persistence question, *not* demand saturation. *(high)*
+- The **AI subset is the growth driver**: ~30–50 TWh in 2023 (10–15% of DC
+  energy) → 200–900 TWh by 2030 (35–50%); AI datacenter power grew ~10× in three
+  years (0.4 GW 2020 → 4.3 GW 2023). *(high)*
+- **Do NOT assert a single physical bottleneck.** "Grid power is the hard
+  constraint" was **refuted 0-3**; "GPU supply is the sole bounding variable"
+  was **refuted 1-2**. The real bound is a blend of chips + capital + energy +
+  grid. Materials limits (TSMC leading-edge, rare earths) and the
+  over-forecasting critique (Jevons offsets, poor DC-forecast track record)
+  produced **no surviving confirmed evidence** — treat both as open.
+
+## 2. Robotics — empirically hollow
+
+- Only *current* density survived verification: **global average 162 robots per
+  10,000 manufacturing workers (2023)**, doubled from 74 in 2016; **Korea leads
+  at 1,012** (only nation >1,000), Singapore 770 (IFR World Robotics 2024).
+  *(high)*
+- **The unit trap (critical for the model):** 162/10,000 *manufacturing* ≈ 16
+  per 1,000 *manufacturing* workers, and manufacturing is ~10–15% of employment,
+  so a whole-economy robots-per-1,000-*total*-workers figure is **~an order of
+  magnitude lower** — even Korea's frontier is only ~15 robots per 1,000 *total*
+  workers today.
+- **No humanoid / general-purpose fleet projection survived verification** —
+  Goldman, Morgan Stanley ($5T market by 2050), ARK, Tesla Optimus, Figure all
+  failed or were absent as too hype-prone to confirm. The robot ceiling
+  therefore **cannot be anchored to any 2035/2050 fleet forecast** from this
+  evidence set; it is a scenario assumption.
+
+## 3. The "feed themselves" / value-vs-cost ceiling — UNCONFIRMED
+
+The intuition that deployment stops where marginal value ≤ marginal cost (an
+EROI-like constraint on capital) is defensible as *structure* but has **no
+verified empirical support here**. The one testable claim — that only ~23% of
+AI-exposed tasks are profitably automatable (cost > benefit for the other 77%,
+"Beyond AI Exposure") — was **refuted 1-2**. Implement value-vs-cost as a
+*mechanism*, not a calibrated break-even.
+
+## 4. The macro / surplus-dissipation angle — STRONGLY SUPPORTED
+
+This is the best-supported part, and it is the defensible (economic) form of the
+Maximum-Power-Principle intuition:
+
+- **Aging *pulls* automation.** Acemoglu & Restrepo (2017, "Secular Stagnation?
+  The Effect of Aging on Economic Growth in the Age of Automation"): faster-aging
+  countries adopt *more* robots; the aging→growth relationship is **positive and
+  significant (0.773)**; automation can fully neutralize or reverse the output
+  loss from a shrinking workforce. *(high)*
+- **The savings glut funds the capital deepening.**
+  Eggertsson-Lancastre-Summers: aging raises savings, lowers the real rate, and
+  deepens the capital stock (incl. AI capital) — **at positive rates**.
+  Kopecky-Taylor ("The Savings Glut of the Old"): aging → rising wealth-income
+  ratio, falling risk-free rate. A recent life-cycle GE model **formally frames
+  the AI shock as a capital-*demand* disturbance and aging/longevity as a
+  saving-*supply* disturbance** — i.e., the exact "surplus savings channel into
+  AI capital" mechanism. *(high; one source non-peer-reviewed)*
+- **Regime caveat:** the stimulative channel **reverses at the zero lower
+  bound** — severe aging pushes the market-clearing rate below zero and capital
+  deepening turns contractionary (post-2008 secular stagnation). So "aging funds
+  AI" holds at positive rates only. *(high)*
+
+---
+
+## 5. Implications for the model
+
+- **`dataCenterSaturation` (6,000 TWh)** — anchor the near term to IEA
+  (415 today → 945 in 2030 → 700–1,700 in 2035-high). 6,000 is ~4× the 2035 high
+  case: a *plausible-high 2050+* backstop, not a forecast — flag the **40×
+  uncertainty**. Low stakes: this output is **GDP-neutral** in the model (a pure
+  electricity sink; lifting it raises generation/WACC, not GDP).
+- **`robotSaturation` (600 per 1,000 workers)** — the exposed one. It is
+  **~600× today's global average (~1/1,000 all workers) and ~35× Korea's current
+  whole-economy frontier (~15/1,000 all workers)** — a humanoids-saturate-all-
+  sectors world, not manufacturing. No fleet forecast supports it. It is also a
+  **top-2 GDP-level dial (1.5–2× GDP 2100)**, so late-century GDP is explicitly
+  conditional on it. Keep as an explicit scenario assumption; band it widely
+  (~100–1,000); disclose in `docs/SENSITIVITY.md`.
+- **The right structural fix (not done yet):** replace both hard saturation caps
+  with an **endogenous "deploy until marginal value ≤ marginal cost" rule** —
+  demand *pulled* by labor scarcity from aging (Acemoglu-Restrepo), *bounded* by
+  capital cost (WACC), energy price, and minerals (`mineralConstraint`). The
+  model already has every piece, and `ai-energy-boom` shows the economic ceiling
+  is latent (self-limits at WACC ~15%). This mirrors the eta-ceiling / VRE /
+  softFloor pattern: replace a non-physical hard cap with the mechanism that
+  should set it. (Bigger change — flagged, not built.)
+
+---
+
+## Sources
+
+- IEA (2025), *Energy and AI* —
+  https://www.iea.org/reports/energy-and-ai/energy-demand-from-ai
+- LBNL (2024), *United States Data Center Energy Usage Report* —
+  https://eta-publications.lbl.gov/sites/default/files/2024-12/lbnl-2024-united-states-data-center-energy-usage-report_1.pdf
+- RAND (2025), AI datacenter power extrapolation —
+  https://www.rand.org/content/dam/rand/pubs/research_reports/RRA3500/RRA3572-1/RAND_RRA3572-1.pdf
+- IEA-4E (2025), *Data Centre Energy Use: Critical Review of Models and
+  Results* —
+  https://www.iea-4e.org/wp-content/uploads/2025/05/Data-Centre-Energy-Use-Critical-Review-of-Models-and-Results.pdf
+- IFR (2024), *World Robotics 2024* / robot-density release —
+  https://ifr.org/ifr-press-releases/news/global-robot-density-in-factories-doubled-in-seven-years
+- Acemoglu & Restrepo (2017), *Secular Stagnation? The Effect of Aging on
+  Economic Growth in the Age of Automation*, NBER/AER P&P —
+  https://economics.mit.edu/sites/default/files/publications/Secular%20Stagnation%20-%20%20The%20Effect%20of%20Aging%20on%20Econo.pdf
+- Eggertsson, Lancastre & Summers, *Aging, Output per Capita and Secular
+  Stagnation* —
+  https://www.ineteconomics.org/uploads/papers/Eggertsson-Lancastre-Summers-Aging-Output-per-Capita-and-Secular-Stagnation.pdf
+- Kopecky & Taylor (2022), *The Savings Glut of the Old*, NBER w29944 —
+  https://www.nber.org/system/files/working_papers/w29944.pdf
+- Morgan Stanley (2025), humanoid market (secondary, unverified) —
+  https://www.morganstanley.com/insights/articles/humanoid-robot-market-5-trillion-by-2050
+
+**Refuted (did not survive verification):** grid-power-as-hard-bottleneck (0-3);
+GPU-supply-as-sole-bound (1-2); the ~23%-profitably-automatable cost-vs-value
+ceiling (1-2).

--- a/src/modules/demand.ts
+++ b/src/modules/demand.ts
@@ -531,12 +531,18 @@ export const demandDefaults: DemandParams = {
   // Robot/automation (endogenous logistic adoption)
   robotBaseline2025: 1,          // 1 robot per 1000 workers in 2025 (IFR World Robotics 2024: ~4.3M industrial robots ≈ 1/1000 of all workers)
   robotBaseGrowth: 0.12,         // Base logistic growth rate (IFR installations grew ~10-14%/yr 2015-2024)
-  // SPECULATIVE — no literature anchor exists for 2100 robot density. 600/1000
-  // workers at 10 MWh each implies ~26,000 TWh/yr by 2100 (comparable to
-  // total world electricity today) and dominates late-century demand growth.
-  // Only the 2025 baseline and near-term growth rate are data-anchored; the
-  // ceiling is a scenario assumption. Treat late-century absolute demand (and
-  // anything downstream of it) as conditional on this choice.
+  // SPECULATIVE — no fleet forecast survives scrutiny (Goldman/Morgan Stanley/
+  // ARK/Tesla humanoid projections were all too hype-prone to verify; see
+  // sources/ai-robotics-deployment-ceilings.md). SCALE CHECK against IFR World
+  // Robotics 2024: today ~1 robot/1000 all-workers globally; the frontier
+  // (Korea) is ~1,012/10,000 MANUFACTURING workers ≈ ~15/1000 ALL workers. So
+  // 600/1000 all-workers is ~600x today's global average and ~35x Korea's
+  // current whole-economy frontier — a humanoids-saturate-ALL-sectors world
+  // (services/logistics/care), not just manufacturing. It implies ~26,000 TWh/yr
+  // by 2100 (≈ all world electricity today). This is a top-2 GDP-LEVEL dial
+  // (1.5-2x GDP 2100), so late-century GDP is explicitly conditional on it.
+  // Treat as a scenario assumption with a wide band (~100-1000); see
+  // docs/SENSITIVITY.md. Only the 2025 baseline and near-term growth are anchored.
   robotSaturation: 600,
   energyPerRobotMWh: 10,        // MWh per robot-unit per year
   robotUnitCost: 80000,         // $ installed per robot-unit: IFR avg unit price ~$27k + integration ~2-3x (2025). INDUSTRIAL-robot anchor: at humanoid-scale densities (ai-energy-boom, 3000/1000) this is an unanchored ~5x extrapolation
@@ -549,11 +555,15 @@ export const demandDefaults: DemandParams = {
   // Datacenter/AI compute (endogenous, distributed by regional GDP)
   dataCenterBaseline2025: 500,        // TWh, IEA/EPRI 2024: datacenters ~1.5% of global elec (~460 TWh); AI inference boost → ~500
   dataCenterBaseGrowth: 0.12,         // Logistic rate; pace matches 2022–2025 hyperscale buildout (~doubling/6yr)
-  // ASSUMPTION beyond ~2030: IEA (2024) projects ~945 TWh by 2030; published
-  // projections thin out beyond that (2050 studies span roughly 1,500-4,000+
-  // TWh). The 6,000 ceiling (~1% of 2100 useful energy) is an asserted
-  // grid/chip/cooling constraint, not a sourced value; the model reaches
-  // ~5,500 TWh by 2050 — above nearly all published projections.
+  // ANCHORED near-term, SPECULATIVE long-term. IEA Energy and AI (2025): ~415
+  // TWh in 2024 (~1.5% of global elec) → Base Case ~945 TWh by 2030 → 700-1,700
+  // TWh by 2035. But 2030 forecasts diverge ~40x (200 to ~8,000 TWh) on whether
+  // exponential chip-supply growth persists — a supply/economics question, not
+  // demand saturation. The 6,000 ceiling is ~4x the 2035 IEA-high case: a
+  // plausible-HIGH 2050+ backstop, not a forecast — read with the 40x band.
+  // LOW STAKES: this load is GDP-NEUTRAL in the model (a pure electricity sink;
+  // lifting it raises generation/WACC, not GDP). No single physical bottleneck
+  // (grid-power-as-hard-limit was refuted). See sources/ai-robotics-deployment-ceilings.md
   dataCenterSaturation: 6000,
   dataCenterEnergySensitivity: 0.4,   // LCOE elasticity: cheap power incentivizes more inference/training capacity
   dataCenterGDPSensitivity: 0.6,      // GDP-per-capita elasticity: compute demand follows wealth (knowledge-economy share)


### PR DESCRIPTION
Docs/comments only — **regression byte-identical**, no parameter values changed.

## What

A verified deep-research pass on what bounds AI-compute and robotics deployment through 2050 (23 sources; 22/25 claims survived 3-vote adversarial verification), used to honestly re-anchor the model's two most speculative automation ceilings.

- **New**: `sources/ai-robotics-deployment-ceilings.md` — the full writeup.
- **`demand.ts`** comment reframes (values unchanged):
  - **`robotSaturation` (600/1,000 workers)** — scale-checked against IFR World Robotics 2024: it's **~600× today's global average** robot density and **~35× Korea's current whole-economy frontier** (~15/1,000 all workers) — a humanoids-in-every-sector assumption, not a forecast (no fleet projection survived verification). Flagged as a **top-2 GDP-level dial (1.6–2.2× GDP 2100)**.
  - **`dataCenterSaturation` (6,000 TWh)** — anchored to IEA *Energy and AI* 2025 (~415 today → ~945 in 2030 → 700–1,700 in 2035), flagged as ~4× the 2035 high case with the **40× forecast spread**, and noted **GDP-neutral** (a pure electricity sink).
- **`docs/SENSITIVITY.md`** — new `robotSaturation` section with the sweep table (GDP 2100 950 → 2,047 across 300 → 2,400) and the WACC column showing the *economic* ceiling that should really bind; top blockquote now names `robotSaturation` as a co-equal dial alongside `serviceEfficiencyGrowth`.

## Key findings

The ceiling is a **supply/economic** question, not demand saturation (AI-energy 2030 forecasts diverge ~40× on whether exponential chip-supply growth persists). The **aging → automation → capital-deepening** pull is the best-supported part (Acemoglu-Restrepo; Eggertsson-Summers / Kopecky-Taylor savings glut). The "feed themselves" cost-vs-value ceiling is intuitive but **unconfirmed** (its one testable claim was refuted). The bigger structural move it points to — replacing both hard caps with an endogenous aging-pull + WACC deployment rule — is flagged in the doc, not built.

## Verification

`npx tsc --noEmit` clean; `npm test` green; `npm run regression` byte-identical across all 7 scenarios (values unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNEmQrZPGGwVksKrmPmSum

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNEmQrZPGGwVksKrmPmSum)_