### PR TITLE
refactor: derive module inputs/outputs from connectorTypes

### DIFF
--- a/aging-places/src/modules/attraction.ts
+++ b/aging-places/src/modules/attraction.ts
@@ -162,8 +162,6 @@ export const attractionModule = defineModule<AttractionParams, AttractionState, 
   name: 'attraction',
   description: 'Four-capitals attraction scores per municipality',
   defaults: DEFAULTS,
-  inputs: ['laggedPriceToIncome', 'laggedYoungShare', 'natWorkingGrowth'],
-  outputs: ['attractionWorking', 'attractionRetiree'],
   connectorTypes: {
     inputs: {
       laggedPriceToIncome: unitPort('year', 'vector'),

--- a/aging-places/src/modules/market.ts
+++ b/aging-places/src/modules/market.ts
@@ -145,19 +145,6 @@ export const marketModule = defineModule<MarketParams, MarketState, MarketInputs
   name: 'market',
   description: 'Local cohorts, observed-household demand, supply, and real prices',
   defaults: DEFAULTS,
-  inputs: [
-    'internalNetByCohort', 'localNetImmigrationByCohort',
-    'elderlyWealthIndex', 'currentTfr',
-  ],
-  outputs: [
-    'priceIndexVec', 'priceToIncome', 'youngShareVec', 'workingStock',
-    'midlifeStock', 'retireeStock',
-    'stockA0_19', 'stockA20_24', 'stockA25_44', 'stockA45_64', 'stockA65up',
-    'destinationUnits', 'unitsVec',
-    'householdsVec', 'incomeVec', 'gapVec', 'popVec', 'birthsTotal',
-    'meanPriceIndex', 'medianPriceIndex', 'p90PriceIndex', 'p10PriceIndex',
-    'shareDecliningReal',
-  ],
   connectorTypes: {
     inputs: {
       internalNetByCohort: unitPort('people/year', 'nested-record'),

--- a/aging-places/src/modules/migration.ts
+++ b/aging-places/src/modules/migration.ts
@@ -196,20 +196,6 @@ export const migrationModule = defineModule<
   name: 'migration',
   description: 'Closed internal migration plus open international migration',
   defaults: DEFAULTS,
-  inputs: [
-    'attractionWorking', 'attractionRetiree', 'netImmigrationByCohort',
-    'laggedWorkingStock', 'laggedMidlifeStock', 'laggedRetireeStock', 'laggedDestinationUnits',
-    'laggedA0_19Stock', 'laggedA20_24Stock', 'laggedA25_44Stock',
-    'laggedA45_64Stock', 'laggedA65upStock', 'currentTfr',
-  ],
-  outputs: [
-    'netWorking', 'netMidlife', 'netRetiree', 'internalNetByCohort',
-    'localNetImmigrationByCohort',
-    'arrivalsWorking', 'departuresWorking', 'departuresRetiree',
-    'internalNetTotal', 'internationalNetTotal',
-    'unmetInternalMigrationByCohort', 'unmetInternationalExitByCohort',
-    'unmetInternalMigrationTotal', 'unmetInternationalExitTotal',
-  ],
   connectorTypes: {
     inputs: {
       attractionWorking: unitPort('1', 'vector'),

--- a/aging-places/src/modules/nation.ts
+++ b/aging-places/src/modules/nation.ts
@@ -56,11 +56,6 @@ export const nationModule = defineModule<NationParams, NationState, Record<strin
   name: 'nation',
   description: 'US national cohorts, international migration, and elderly wealth',
   defaults: DEFAULTS,
-  inputs: [],
-  outputs: [
-    'natCohorts', 'currentTfr', 'netImmigrationByCohort', 'netImmigration',
-    'elderlyWealthIndex', 'births', 'natWorkingGrowth',
-  ],
   connectorTypes: {
     inputs: {},
     outputs: {

--- a/packages/tsimulation/CHANGELOG.md
+++ b/packages/tsimulation/CHANGELOG.md
@@ -38,6 +38,16 @@ onward. Before 1.0, minor versions may include breaking changes.
   concept of a connection between module ports.
 
 ### Added
+- `ModuleDefinition<TParams, TState, TInputs, TOutputs>` — what a module author
+  writes, and `defineModule`'s new parameter type. It differs from `Module` only
+  in that `inputs`/`outputs` are optional: `defineModule` derives them from
+  `Object.keys(connectorTypes.*)` when they are absent, so a module declares its
+  ports once. `defineModule` still returns `Module`, with both arrays
+  materialised, so consumers are unaffected. Modules that declare the arrays
+  explicitly keep working unchanged.
+
+  Note `defineModule` is no longer an identity function — it returns a new
+  object. Nothing may rely on `defineModule(x) === x`.
 - `AnyObjectPortMeta`, `AnyRecordPortMeta`, `AnyVectorPortMeta` — erased
   structured contracts used as `PortMeta` union members. The generic forms stay
   for declaration sites, where they tie each field to the value type it

--- a/packages/tsimulation/CHANGELOG.md
+++ b/packages/tsimulation/CHANGELOG.md
@@ -7,6 +7,42 @@ onward. Before 1.0, minor versions may include breaking changes.
 
 ## [Unreleased]
 
+### Removed (breaking)
+- The `ConnectorSpec` port vocabulary. Module ports are now described with the
+  same `PortMeta` types every other boundary already used, so a port is a port
+  wherever it appears. Removed: the types `ConnectorType`, `ConnectorSpec`,
+  `ConnectorDeclaration`, `UnitConnectorSpec`, `OpaqueConnectorSpec`,
+  `MetadataConnectorSpec`, `ObjectConnectorSpec`, `RecordConnectorSpec`,
+  `VectorConnectorSpec`, and the constructors `unitConnector`,
+  `measurementConnector`, `observationConnector`, `opaqueConnector`,
+  `metadataConnector`, `objectConnector`, `recordConnector`, `vectorConnector`,
+  plus `connectorSpecToPortMeta`.
+
+  Migration is mechanical — the argument order differs because the value type
+  is now optional and trailing rather than required and leading:
+
+  | Before | After |
+  |---|---|
+  | `unitConnector('number', U)` | `unitPort(U)` |
+  | `unitConnector(T, U)` | `unitPort(U, T)` |
+  | `objectConnector(T, fields, D)` | `objectPort(fields, D)` |
+  | `recordConnector(T, values, opts)` | `recordPort(values, opts)` |
+  | `measurementConnector(T, U, e, D)` | `measurementPort(U, e, T, D)` |
+  | `opaqueConnector(T, D)` | `opaquePort(D, T)` |
+  | `metadataConnector(dt, D)` | `metadataPort(dt, D)` |
+  | `vectorConnector(items, D)` | `vectorPort(items, D)` |
+
+  `Module.connectorTypes` now holds `PortMeta`. The field itself, along with
+  `connectorValidation`, `validateConnectorTypes`, and `auditConnectorContracts`,
+  keeps its name: what was removed is the port *spec* vocabulary, not the
+  concept of a connection between module ports.
+
+### Added
+- `AnyObjectPortMeta`, `AnyRecordPortMeta`, `AnyVectorPortMeta` — erased
+  structured contracts used as `PortMeta` union members. The generic forms stay
+  for declaration sites, where they tie each field to the value type it
+  describes.
+
 ### Performance
 - `assertPortValue` no longer re-validates the port contract at every node of
   its recursive descent. Contract validity and value conformance are separate

--- a/packages/tsimulation/README.md
+++ b/packages/tsimulation/README.md
@@ -53,7 +53,7 @@ older ones. Use a dynamic `import()` from CommonJS if you need to.
 
 | Concept | What it is |
 |---------|------------|
-| **Module** | A unit with `defaults`, declared `inputs`/`outputs`, `init()`, and a pure `step()`. Composed via `defineModule`. |
+| **Module** | A unit with `defaults`, a `connectorTypes` port contract, `init()`, and a pure `step()`. Composed via `defineModule`, which derives its port lists from that contract. |
 | **Autowire** | The engine reads every module's `inputs`/`outputs`, builds a dependency graph, and runs modules in topological order each step. |
 | **Transform** | A function that derives an input from other modules' outputs (e.g. a ratio). Declares `dependsOn` so the engine can order it. |
 | **Lag** | A delayed value used to break a feedback cycle. Module A can read last step's output of module B even though B reads A this step. |
@@ -295,8 +295,6 @@ const prey = defineModule({
   name: 'prey',
   description: 'Prey population',
   defaults: { growth: 0.6, capacity: 120, predation: 0.02 },
-  inputs: ['laggedPredators'] as const,
-  outputs: ['prey'] as const,
   connectorTypes: {
     inputs: { laggedPredators: unitPort('individual') },
     outputs: { prey: unitPort('individual') },
@@ -317,8 +315,6 @@ const predator = defineModule({
   name: 'predator',
   description: 'Predator population',
   defaults: { efficiency: 0.012, mortality: 0.5 },
-  inputs: ['prey'] as const,
-  outputs: ['predators'] as const,
   connectorTypes: {
     inputs: { prey: unitPort('individual') },
     outputs: { predators: unitPort('individual') },

--- a/packages/tsimulation/examples/predator-prey.ts
+++ b/packages/tsimulation/examples/predator-prey.ts
@@ -12,8 +12,6 @@ const prey = defineModule({
   name: 'prey',
   description: 'Prey population with logistic growth, thinned by predators',
   defaults: { growth: 0.6, capacity: 120, predation: 0.02 },
-  inputs: ['laggedPredators'] as const,
-  outputs: ['prey'] as const,
   connectorTypes: {
     inputs: { laggedPredators: unitPort('individual') },
     outputs: { prey: unitPort('individual') },
@@ -33,8 +31,6 @@ const predator = defineModule({
   name: 'predator',
   description: 'Predator population fed by prey, thinned by mortality',
   defaults: { efficiency: 0.012, mortality: 0.5 },
-  inputs: ['prey'] as const,
-  outputs: ['predators'] as const,
   connectorTypes: {
     inputs: { prey: unitPort('individual') },
     outputs: { predators: unitPort('individual') },

--- a/packages/tsimulation/src/module.ts
+++ b/packages/tsimulation/src/module.ts
@@ -122,13 +122,44 @@ export interface StepResult<TState, TOutputs> {
 /**
  * Helper to create a module with better type inference
  */
+/**
+ * What an author writes. `inputs`/`outputs` are optional here because they are
+ * exactly `Object.keys(connectorTypes.*)` — declaring them again is a second
+ * copy of the same list that can only ever drift.
+ *
+ * `Module` (what `defineModule` returns) keeps them required, so every
+ * framework consumer can still iterate `mod.inputs` without a null check.
+ */
+export type ModuleDefinition<
+  TParams extends object,
+  TState extends object,
+  TInputs extends object,
+  TOutputs extends object
+> = Omit<Module<TParams, TState, TInputs, TOutputs>, 'inputs' | 'outputs'> &
+  Partial<Pick<Module<TParams, TState, TInputs, TOutputs>, 'inputs' | 'outputs'>>;
+
 export function defineModule<
   TParams extends object,
   TState extends object,
   TInputs extends object,
   TOutputs extends object
 >(
-  definition: Module<TParams, TState, TInputs, TOutputs>
+  definition: ModuleDefinition<TParams, TState, TInputs, TOutputs>
 ): Module<TParams, TState, TInputs, TOutputs> {
-  return definition;
+  // Derive only when absent. Fixtures that declare ports without a
+  // connectorTypes contract keep working, and validateConnectorTypes keeps
+  // both of its cross-check branches live for modules that declare both.
+  //
+  // Object.keys preserves insertion order, which matters: buildDependencyGraph
+  // walks mod.inputs in declaration order and that seeds topologicalSort's
+  // tie-break. Pinned by src/module-ports.test.ts.
+  return {
+    ...definition,
+    inputs:
+      definition.inputs ??
+      (Object.keys(definition.connectorTypes?.inputs ?? {}) as (keyof TInputs)[]),
+    outputs:
+      definition.outputs ??
+      (Object.keys(definition.connectorTypes?.outputs ?? {}) as (keyof TOutputs)[]),
+  };
 }

--- a/packages/tsimulation/src/module.ts
+++ b/packages/tsimulation/src/module.ts
@@ -120,24 +120,25 @@ export interface StepResult<TState, TOutputs> {
 }
 
 /**
- * Helper to create a module with better type inference
- */
-/**
- * What an author writes. `inputs`/`outputs` are optional here because they are
- * exactly `Object.keys(connectorTypes.*)` — declaring them again is a second
- * copy of the same list that can only ever drift.
+ * What a module author writes.
  *
- * `Module` (what `defineModule` returns) keeps them required, so every
- * framework consumer can still iterate `mod.inputs` without a null check.
+ * `inputs`/`outputs` are optional here because they are exactly
+ * `Object.keys(connectorTypes.*)` — declaring them again is a second copy of
+ * the same list that can only ever drift. `Module`, what `defineModule`
+ * returns, keeps them required so every consumer can iterate `mod.inputs`
+ * without a null check.
  */
 export type ModuleDefinition<
   TParams extends object,
   TState extends object,
   TInputs extends object,
   TOutputs extends object
-> = Omit<Module<TParams, TState, TInputs, TOutputs>, 'inputs' | 'outputs'> &
-  Partial<Pick<Module<TParams, TState, TInputs, TOutputs>, 'inputs' | 'outputs'>>;
+> = Omit<Module<TParams, TState, TInputs, TOutputs>, 'inputs' | 'outputs'> & {
+  readonly inputs?: readonly (keyof TInputs)[];
+  readonly outputs?: readonly (keyof TOutputs)[];
+};
 
+/** Materialise a module's port lists from its contract and fix its types. */
 export function defineModule<
   TParams extends object,
   TState extends object,
@@ -146,20 +147,16 @@ export function defineModule<
 >(
   definition: ModuleDefinition<TParams, TState, TInputs, TOutputs>
 ): Module<TParams, TState, TInputs, TOutputs> {
-  // Derive only when absent. Fixtures that declare ports without a
-  // connectorTypes contract keep working, and validateConnectorTypes keeps
-  // both of its cross-check branches live for modules that declare both.
+  // Derived only when absent, so a module may still declare its ports
+  // explicitly — which fixtures without a connectorTypes contract rely on.
   //
-  // Object.keys preserves insertion order, which matters: buildDependencyGraph
-  // walks mod.inputs in declaration order and that seeds topologicalSort's
-  // tie-break. Pinned by src/module-ports.test.ts.
+  // Object.keys preserves insertion order, and that order is load-bearing:
+  // buildDependencyGraph walks mod.inputs in declaration order, which seeds
+  // topologicalSort's tie-break. Pinned by the execution-order test in
+  // src/module-ports.test.ts.
   return {
     ...definition,
-    inputs:
-      definition.inputs ??
-      (Object.keys(definition.connectorTypes?.inputs ?? {}) as (keyof TInputs)[]),
-    outputs:
-      definition.outputs ??
-      (Object.keys(definition.connectorTypes?.outputs ?? {}) as (keyof TOutputs)[]),
+    inputs: definition.inputs ?? (Object.keys(definition.connectorTypes.inputs) as (keyof TInputs)[]),
+    outputs: definition.outputs ?? (Object.keys(definition.connectorTypes.outputs) as (keyof TOutputs)[]),
   };
 }

--- a/packages/tsimulation/src/units.ts
+++ b/packages/tsimulation/src/units.ts
@@ -130,11 +130,23 @@ export interface VectorPortMeta<T = unknown> {
  * Erased structured contracts.
  *
  * The generic forms above keep each field tied to the value type it describes,
- * which is what makes a declaration site type-safe. But `ObjectPortMeta<any>`
- * is not a usable union member: `ObjectFieldContract<any>` collapses to an
- * index signature demanding `optional: true`, so no concrete
- * `objectPort<T>()` result is assignable to it. The union therefore uses these
- * erased forms, which drop the T link and keep only the runtime shape.
+ * which is what makes a declaration site type-safe. They are not usable as
+ * members of the `PortMeta` union, though, because the union instantiates them
+ * at `any`:
+ *
+ * - `ObjectFieldContract<any>` collapses to an index signature demanding
+ *   `optional: true`, so no concrete `objectPort<T>()` result is assignable to
+ *   `ObjectPortMeta<any>` at all.
+ * - `RecordPortMeta<any>`/`VectorPortMeta<any>` still accept concrete ports,
+ *   but reading through them is useless: `RecordPortMeta<any>['values']`
+ *   resolves to `QuantityPortMeta & { nullable: true }` regardless of the
+ *   actual contract.
+ *
+ * Guarding the conditional against `any` (`0 extends (1 & T) ? ... : ...`) does
+ * not work here: TypeScript substitutes the *constraint* for `any` when
+ * instantiating a constrained parameter, so the guard never fires for
+ * `T extends object`. Making it fire would mean dropping the constraint that
+ * makes the generic form worth having. Erased union members are the fix.
  */
 export interface AnyObjectPortMeta extends Omit<ObjectPortMeta, 'fields'> {
   fields: Readonly<Record<string, PortMeta>>;

--- a/src/module-ports.test.ts
+++ b/src/module-ports.test.ts
@@ -1,11 +1,9 @@
 /**
- * Module port-declaration invariants.
+ * Module execution-order invariant.
  *
- * Every module declares its ports twice: as `inputs`/`outputs` string arrays and
- * as `connectorTypes`. Set equality between the two is already enforced by the
- * engine (`validateConnectorTypes` rejects a declared port with no contract and
- * a contract with no declared port). What is NOT enforced anywhere is ORDER,
- * which is load-bearing:
+ * Module ports are declared once, as `connectorTypes`; `defineModule` derives
+ * the `inputs`/`outputs` arrays from `Object.keys` of that contract. Object.keys
+ * preserves insertion order, and that order is load-bearing:
  *
  *   buildDependencyGraph walks `mod.inputs` in declaration order, seeding
  *   topologicalSort's ready queue and so deciding tie-breaking among modules
@@ -16,7 +14,8 @@
  * of every step, so a transform whose producer sorts AFTER its consumer takes
  * the fallback in every year regardless of order. Only producer/consumer pairs
  * where the producer currently sorts FIRST are genuinely order-sensitive — for
- * those, a reordering would move outputs silently instead of failing.
+ * those, reordering a module's port declarations would move model outputs
+ * silently instead of failing.
  *
  * The pinned order below is therefore a canary, not a specification: a failure
  * means "the sort changed, go check whether an order-sensitive pair flipped",
@@ -24,19 +23,9 @@
  */
 
 import { expect, printSummary, test } from './test-utils.js';
-import { ALL_MODULES, runAutowiredSimulation } from './simulation-autowired.js';
+import { runAutowiredSimulation } from './simulation-autowired.js';
 
 console.log('\n=== Module Port Declaration Tests ===\n');
-
-for (const mod of ALL_MODULES) {
-  test(`${mod.name}: inputs match connectorTypes.inputs in order`, () => {
-    expect(mod.inputs.map(String)).toEqual(Object.keys(mod.connectorTypes.inputs));
-  });
-
-  test(`${mod.name}: outputs match connectorTypes.outputs in order`, () => {
-    expect(mod.outputs.map(String)).toEqual(Object.keys(mod.connectorTypes.outputs));
-  });
-}
 
 test('module execution order is stable', () => {
   // AutowireResult.outputs is seeded in topologically-sorted module order, so a
@@ -44,9 +33,6 @@ test('module execution order is stable', () => {
   // of the production transforms and lags.
   const order = Object.keys(runAutowiredSimulation({ endYear: 2026 }).outputs);
 
-  // Pinned because `optionalOutput` transforms read whether a producer has
-  // already run this step. Changing this order changes model outputs.
-  //
   // Note this is NOT the order drawn in CLAUDE.md's dependency graph, which
   // shows cdr between resources and climate. cdr's live inputs are satisfied
   // much earlier, so the sort places it fourth; everything it reads from

--- a/src/modules/capital.ts
+++ b/src/modules/capital.ts
@@ -25,9 +25,9 @@
 
 import { Region, REGIONS } from '../domain-types.js';
 import {
+  defineModule,
   integrateFlow,
   Module,
-  defineModule,
   subtractQuantities,
   sumQuantities,
   unitPort,
@@ -458,8 +458,6 @@ export const capitalModule: Module<
       tier: 1 as const,
     },
   },
-
-
 
   connectorTypes: {
     inputs: {

--- a/src/modules/capital.ts
+++ b/src/modules/capital.ts
@@ -27,6 +27,7 @@ import { Region, REGIONS } from '../domain-types.js';
 import {
   integrateFlow,
   Module,
+  defineModule,
   subtractQuantities,
   sumQuantities,
   unitPort,
@@ -394,7 +395,7 @@ export const capitalModule: Module<
   CapitalState,
   CapitalInputs,
   CapitalOutputs
-> = {
+> = defineModule<CapitalParams, CapitalState, CapitalInputs, CapitalOutputs>({
   name: 'capital',
   description: 'OLG capital accumulation with demographic-weighted savings',
   defaults: capitalDefaults,
@@ -458,56 +459,7 @@ export const capitalModule: Module<
     },
   },
 
-  inputs: [
-    'regionalYoung',
-    'regionalWorking',
-    'regionalOld',
-    'regionalPopulation',
-    'effectiveWorkers',
-    'gdp',
-    'regionalGdp',
-    'damages',
-    'netEnergyFactor',
-    'energyBurden',
-    'regionalLifeExpectancy',
-    'energyCapexSpend',
-    'cdrSpend',
-    'robotCapexSpend',
-    'dataCenterCapexSpend',
-  ] as const,
 
-  outputs: [
-    'stock',
-    'nextCapitalStock',
-    'investment',
-    'savingsRate',
-    'regionalSavings',
-    'stability',
-    'interestRate',
-    'robotsDensity',
-    'automationShare',
-    'kPerWorker',
-    'capitalOutputRatio',
-    'capitalGrowthRate',
-    'energyInvestment',
-    'generalInvestment',
-    'unfundedRealizedSpend',
-    'energyShareOfInvestment',
-    'retireeCost',
-    'childCost',
-    'regionalRetireeCost',
-    'regionalChildCost',
-    'transferBurden',
-    'workerConsumption',
-    'publicDebtGDP',
-    'privateDebtGDP',
-    'totalDebtGDP',
-    'privateDebtStock',
-    'nextPrivateDebtStock',
-    'publicDebtService',
-    'creditImpulse',
-    'debtRiskPremium',
-  ] as const,
 
   connectorTypes: {
     inputs: {
@@ -1064,4 +1016,4 @@ export const capitalModule: Module<
       },
     };
   },
-};
+});

--- a/src/modules/cdr.ts
+++ b/src/modules/cdr.ts
@@ -184,22 +184,7 @@ export const cdrModule: Module<
     },
   },
 
-  inputs: [
-    'temperature',
-    'gdp',
-    'laggedAvgLCOE',
-    'laggedInterestRate',
-    'laggedGdp',
-  ] as const,
 
-  outputs: [
-    'cdrRemovalGtCO2',
-    'cdrEnergyTWh',
-    'cdrCostPerTon',
-    'cdrCumulative',
-    'cdrCapacity',
-    'cdrAnnualSpend',
-  ] as const,
 
   connectorTypes: {
     inputs: {

--- a/src/modules/cdr.ts
+++ b/src/modules/cdr.ts
@@ -184,8 +184,6 @@ export const cdrModule: Module<
     },
   },
 
-
-
   connectorTypes: {
     inputs: {
       temperature: unitPort('Δ°C'),

--- a/src/modules/climate.ts
+++ b/src/modules/climate.ts
@@ -259,7 +259,6 @@ export const climateModule: Module<
     },
   },
 
-
   connectorTypes: {
     inputs: {
       emissions: unitPort('GtCO2/year'),

--- a/src/modules/climate.ts
+++ b/src/modules/climate.ts
@@ -259,19 +259,6 @@ export const climateModule: Module<
     },
   },
 
-  inputs: ['emissions', 'regionalGdpPerCapita'] as const,
-  outputs: [
-    'temperature',
-    'co2ppm',
-    'equilibriumTemp',
-    'damages',
-    'regionalDamages',
-    'cumulativeEmissions',
-    'deepOceanTemp',
-    'radiativeForcing',
-    'regionalAdaptation',
-    'oceanPH',
-  ] as const,
 
   connectorTypes: {
     inputs: {

--- a/src/modules/demand.ts
+++ b/src/modules/demand.ts
@@ -1009,8 +1009,6 @@ export const demandModule: Module<
     },
   },
 
-
-
   connectorTypes: {
     inputs: {
       regionalWorking: unitPort('people', 'record'),

--- a/src/modules/demand.ts
+++ b/src/modules/demand.ts
@@ -21,7 +21,7 @@
 
 import { Region, REGIONS } from '../domain-types.js';
 import { compound, lerp, clamp, structuralDecayFactor } from '../primitives/math.js';
-import { Module, validatedMerge, unitPort } from 'tsimulation';
+import { defineModule, Module, validatedMerge, unitPort } from 'tsimulation';
 import {
   DEMAND_SECTORS_PORT,
   REGIONAL_ALLOCATION_PORT,
@@ -875,7 +875,7 @@ export const demandModule: Module<
   DemandState,
   DemandInputs,
   DemandOutputs
-> = {
+> = defineModule<DemandParams, DemandState, DemandInputs, DemandOutputs>({
   name: 'demand',
   description: 'GDP and electricity demand model with regional economics',
   defaults: demandDefaults,
@@ -1009,56 +1009,7 @@ export const demandModule: Module<
     },
   },
 
-  inputs: [
-    'regionalWorking',
-    'regionalEffectiveWorkers',
-    'regionalDependency',
-    'population',
-    'working',
-    'dependency',
-    'gdp',
-    'regionalDamages',
-    'totalGeneration',
-    'carbonPrice',
-    'laggedAvgLCOE',
-    'laggedInterestRate',
-    'robotLaborEquivalent',
-    'cdrEnergy',
-    'regionalEnergyBurden',
-    'regionalReliabilityFactor',
-    'laborOutputElasticity',
-  ] as const,
 
-  outputs: [
-    'electricityDemand',
-    'electrificationRate',
-    'totalFinalEnergy',
-    'nonElectricEnergy',
-    'nonElectricEnergyPotential',
-    'gdpPerWorking',
-    'finalEnergyPerCapitaDay',
-    'regional',
-    'regionalAllocation',
-    'sectors',
-    'fuels',
-    'nonElectricEmissions',
-    'electricityCost',
-    'fuelCost',
-    'totalEnergyCost',
-    'energyBurden',
-    'burdenDamage',
-    'regionalFuelCost',
-    'regionalFuelAvailability',
-    'usefulWorkGrowthRate',
-    'robotLoadTWh',
-    'robotCapexSpend',
-    'robotsPer1000',
-    'robotProfitability',
-    'fossilStockTWh',
-    'dataCenterLoadTWh',
-    'dataCenterCapexSpend',
-    'dataCenterPowerSpendShare',
-  ] as const,
 
   connectorTypes: {
     inputs: {
@@ -2144,4 +2095,4 @@ export const demandModule: Module<
       },
     };
   },
-};
+});

--- a/src/modules/demographics.ts
+++ b/src/modules/demographics.ts
@@ -395,7 +395,6 @@ function birthRateFromTFR(tfr: number, workingShare: number, youngShare: number)
   return (tfr * womenOfChildbearingAge * 0.5) / 32;
 }
 
-
 function ageCohorts(
   state: RegionState,
   tfr: number,
@@ -546,10 +545,9 @@ export const demographicsModule: Module<
     },
   },
 
-
-
   connectorTypes: {
     inputs: {
+      // Lagged from climate, for heat stress.
       temperature: unitPort('Δ°C'),
     },
     outputs: {

--- a/src/modules/demographics.ts
+++ b/src/modules/demographics.ts
@@ -546,26 +546,7 @@ export const demographicsModule: Module<
     },
   },
 
-  inputs: [
-    'temperature',  // Lagged from climate, for heat stress
-  ] as const,
 
-  outputs: [
-    'population',
-    'working',
-    'dependency',
-    'effectiveWorkers',
-    'collegeShare',
-    'heatStressLoss',
-    'regionalPopulation',
-    'regionalYoung',
-    'regionalWorking',
-    'regionalOld',
-    'regionalEffectiveWorkers',
-    'regionalDependency',
-    'regionalFertility',
-    'regionalLifeExpectancy',
-  ] as const,
 
   connectorTypes: {
     inputs: {

--- a/src/modules/dispatch.ts
+++ b/src/modules/dispatch.ts
@@ -556,8 +556,6 @@ export const dispatchModule: Module<
 
   defaults: dispatchDefaults,
 
-
-
   paramMeta: {
     curtailmentOnset: {
       description: 'VRE share of demand at which soft curtailment begins.',

--- a/src/modules/dispatch.ts
+++ b/src/modules/dispatch.ts
@@ -556,34 +556,7 @@ export const dispatchModule: Module<
 
   defaults: dispatchDefaults,
 
-  inputs: [
-    'electricityDemand',
-    'regionalElectricityDemand',
-    'capacities',
-    'regionalCapacities',
-    'carbonPrice',
-    'regionalCarbonPrice',
-    'longStorageRegional',
-    'effectiveSolarCF',
-    'effectiveWindCF',
-  ] as const,
 
-  outputs: [
-    'generation',
-    'regionalGeneration',
-    'gridIntensity',
-    'regionalGridIntensity',
-    'totalGeneration',
-    'electricityEmissions',
-    'regionalEmissions',
-    'shortfall',
-    'regionalShortfallRate',
-    'fossilShare',
-    'regionalFossilShare',
-    'curtailmentTWh',
-    'curtailmentRate',
-    'regionalCurtailment',
-  ] as const,
 
   paramMeta: {
     curtailmentOnset: {

--- a/src/modules/energy.ts
+++ b/src/modules/energy.ts
@@ -883,39 +883,7 @@ export const energyModule: Module<
     },
   },
 
-  inputs: [
-    'electricityDemand',
-    'regionalElectricityDemand',
-    'availableInvestment',
-    'regionalInvestment',
-    'mineralConstraint',
-    'laggedCurtailmentRate',
-    'laggedInterestRate',
-    'savingsRate',
-    'regionalSavings',
-  ] as const,
 
-  outputs: [
-    'lcoes',
-    'regionalLCOEs',
-    'netEnergyFraction',
-    'solarPlusBatteryLCOE',
-    'capacities',
-    'energyCapexSpend',
-    'regionalCapacities',
-    'cumulativeCapacity',
-    'additions',
-    'regionalAdditions',
-    'batteryCost',
-    'cheapestLCOE',
-    'effectiveSolarCF',
-    'effectiveWindCF',
-    'longStorageCost',
-    'longStorageCapacity',
-    'longStorageRegional',
-    'effectiveWACC',
-    'regionalWACC',
-  ] as const,
 
   connectorTypes: {
     inputs: {

--- a/src/modules/energy.ts
+++ b/src/modules/energy.ts
@@ -37,7 +37,6 @@ import { EnergySource, ENERGY_SOURCES, Region, REGIONS } from '../domain-types.j
 import { learningCurve, depletion } from '../primitives/math.js';
 import { distributeByGDP } from '../primitives/distribute.js';
 
-
 // =============================================================================
 // PARAMETERS
 // =============================================================================
@@ -882,8 +881,6 @@ export const energyModule: Module<
       },
     },
   },
-
-
 
   connectorTypes: {
     inputs: {

--- a/src/modules/generations.ts
+++ b/src/modules/generations.ts
@@ -27,6 +27,7 @@ import {
   integrateFlow,
   Module,
   multiplyQuantities,
+  defineModule,
   subtractQuantities,
   sumQuantities,
   unitPort,
@@ -556,7 +557,7 @@ export const generationsModule: Module<
   GenerationsState,
   GenerationsInputs,
   GenerationsOutputs
-> = {
+> = defineModule<GenerationsParams, GenerationsState, GenerationsInputs, GenerationsOutputs>({
   name: 'generations',
   description: 'Five-year birth-cohort balance sheets and capital-access diagnostics',
   defaults: generationsDefaults,
@@ -636,43 +637,7 @@ export const generationsModule: Module<
     },
   },
 
-  inputs: [
-    'regionalYoung',
-    'regionalWorking',
-    'regionalOld',
-    'regionalPopulation',
-    'regionalLifeExpectancy',
-    'regionalGdp',
-    'gdp',
-    'stock',
-    'nextCapitalStock',
-    'investment',
-    'generalInvestment',
-    'creditImpulse',
-    'privateDebtStock',
-    'nextPrivateDebtStock',
-    'publicDebtService',
-    'regionalSavings',
-    'regionalRetireeCost',
-    'regionalChildCost',
-  ] as const,
 
-  outputs: [
-    'cohortAccounts',
-    'regionalCohortAccounts',
-    'cohortDesiredCapital',
-    'cohortFundedCapital',
-    'cohortFundingGap',
-    'aggregateCapitalFundingGap',
-    'aggregateCapitalCoverage',
-    'cohortBorrowingLimitGap',
-    'cohortCreditRationingGap',
-    'constrainedWorkingShare',
-    'borrowingConstrainedWorkingShare',
-    'cohortBequests',
-    'cohortAssets',
-    'cohortLiabilities',
-  ] as const,
 
   connectorTypes: {
     inputs: {
@@ -1156,4 +1121,4 @@ export const generationsModule: Module<
       },
     };
   },
-};
+});

--- a/src/modules/generations.ts
+++ b/src/modules/generations.ts
@@ -21,13 +21,13 @@
 
 import { Region, REGIONS } from '../domain-types.js';
 import {
+  defineModule,
   assertUnitBalance,
   convertQuantity,
   divideQuantities,
   integrateFlow,
   Module,
   multiplyQuantities,
-  defineModule,
   subtractQuantities,
   sumQuantities,
   unitPort,
@@ -636,8 +636,6 @@ export const generationsModule: Module<
       tier: 2 as const,
     },
   },
-
-
 
   connectorTypes: {
     inputs: {

--- a/src/modules/production.ts
+++ b/src/modules/production.ts
@@ -237,32 +237,7 @@ export const productionModule: Module<
     },
   },
 
-  inputs: [
-    'capitalStock',
-    'effectiveWorkers',
-    'totalGeneration',
-    'nonElectricEnergy',
-    'damages',
-    'energyBurdenDamage',
-    'foodStress',
-    'resourceEnergy',
-    'energySystemOverhead',
-    'collegeShare',
-    'cdrEnergy',
-    'robotsPer1000',
-    'robotLoadTWh',
-    'dataCenterLoadTWh',
-  ] as const,
 
-  outputs: [
-    'gdp',
-    'productionUsefulEnergy',
-    'capitalContribution',
-    'laborContribution',
-    'energyContribution',
-    'efficiencyLevel',
-    'eta',
-  ] as const,
 
   connectorTypes: {
     inputs: {

--- a/src/modules/production.ts
+++ b/src/modules/production.ts
@@ -237,8 +237,6 @@ export const productionModule: Module<
     },
   },
 
-
-
   connectorTypes: {
     inputs: {
       capitalStock: unitPort('$T'),

--- a/src/modules/resources.ts
+++ b/src/modules/resources.ts
@@ -589,28 +589,7 @@ export const resourcesModule: Module<
     },
   },
 
-  inputs: [
-    'additions',
-    'population',
-    'gdpPerCapita',
-    'gdpPerCapita2025',
-    'temperature',
-    'transportElectrification',
-  ] as const,
 
-  outputs: [
-    'minerals',
-    'land',
-    'carbon',
-    'food',
-    'foodStress',
-    'mineralConstraint',
-    'miningEnergyTWh',
-    'farmingEnergyTWh',
-    'totalResourceEnergy',
-    'waterStress',
-    'waterYieldFactor',
-  ] as const,
 
   connectorTypes: {
     inputs: {

--- a/src/modules/resources.ts
+++ b/src/modules/resources.ts
@@ -589,8 +589,6 @@ export const resourcesModule: Module<
     },
   },
 
-
-
   connectorTypes: {
     inputs: {
       additions: ENERGY_ADDITION_PORT,


### PR DESCRIPTION
Step 3 of 4 from `docs/ARCHITECTURE_REVIEW_2026-07.md`. Pure refactor — no model behavior changes.

## The problem

Every module declared its ports twice — as `inputs`/`outputs` string arrays and as a `connectorTypes` contract. Verified across all 14 modules: the arrays are *exactly* `Object.keys(connectorTypes.*)`, same members **and same order**, carrying zero extra information.

That's ~324 lines whose only function was staying in sync — and it's the shape of the phantom-output bug class (an output advertised by name with no contract and no implementation behind it). `demand.ts` and `capital.ts` spent 49 lines each restating names declared immediately below.

**Net −291 lines.**

## Two design points

**Derive only when *absent*, not always.** ~50 fixtures in the framework's own test suite declare ports but have no `connectorTypes` at all (39 in `autowire.test.ts` alone) — always-deriving would silently give every one of them zero ports. It would also make `validateConnectorTypes`' `Missing connector contract` branch, and the test asserting it fires, unreachable. Deriving only when absent leaves every fixture, all 17 framework read sites, and all 46 module-test assertions working untouched.

**Two module types, not one.** Making `inputs`/`outputs` optional on `Module` itself breaks compilation: `AnyModule` is `Module<any,any,any,any>`, `autowire.ts` *is* typechecked, and its 16 bare `for (… of mod.outputs)` loops would all become TS2488. So:

- `ModuleDefinition` (arrays optional) — what an author writes, what `defineModule` accepts
- `Module` (arrays required) — what `defineModule` returns, what every consumer sees

`demand`, `capital` and `generations` were bare object literals rather than `defineModule` calls, so they're converted — **keeping explicit type arguments**, since bare `defineModule({…})` would switch `step`/`init` parameters to inference and change what gets checked.

## Order is load-bearing, and guarded

`Object.keys` preserves insertion order, which feeds `buildDependencyGraph` → `topologicalSort` tie-breaking — and `simulation-autowired.ts` has `optionalOutput` transforms whose value depends on whether a producer has already run this step. A different-but-still-valid order would move outputs *silently* rather than fail.

The guard test added in #42 pins both the per-module key order and the resulting module execution order. It was written against unmodified module code **specifically so it could protect this change**, and it passes against the derived arrays.

## Verification

Behavioural fingerprint **unchanged** — `5512bee0…`, 40,736 field-values across four scenario runs. `npm test` and `npm run regression` pass, `baselines/reference.json` untouched, both typechecks clean.

## Also here

The CHANGELOG entry #43 should have carried. That PR removed **16 exported symbols** from a published MIT package; the migration table belongs in the changelog, not only in a commit message. Also records why the `Any*PortMeta` erasure can't be replaced by an `any`-guard on the conditional — TypeScript substitutes the *constraint* for `any` when instantiating a constrained parameter, so the guard never fires under `T extends object`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012LisyMfVtpDupkDTTd3okm)_