### PR TITLE
Harden semantic and stock-flow accounting

### DIFF
--- a/aging-places/src/attraction.test.ts
+++ b/aging-places/src/attraction.test.ts
@@ -1,5 +1,9 @@
 import { expect, printSummary, test } from '../../src/test-utils.js';
-import { concentrationShift, universityThroughputRetention } from './modules/attraction.js';
+import {
+  attractionModule,
+  concentrationShift,
+  universityThroughputRetention,
+} from './modules/attraction.js';
 
 console.log('\n=== Aging Places Attraction Scenario Tests ===\n');
 
@@ -34,6 +38,18 @@ test('concentration dial ramps linearly and saturates at deep decline', () => {
 
 test('a degenerate growth band disables the dial instead of dividing by zero', () => {
   expect(concentrationShift(1, 0, 0.005, 0.005)).toBe(0);
+});
+
+test('concentration rejects a zero institutional-weight denominator', () => {
+  const validation = attractionModule.validate(
+    attractionModule.mergeParams({
+      wEngines: 0,
+      wHuman: 0,
+      concentrationSensitivity: 1,
+    }),
+  );
+  expect(validation.valid).toBeFalse();
+  expect(validation.errors.join(' ').includes('wEngines + wHuman')).toBeTrue();
 });
 
 printSummary();

--- a/aging-places/src/modules/attraction.ts
+++ b/aging-places/src/modules/attraction.ts
@@ -193,6 +193,14 @@ export const attractionModule = defineModule<AttractionParams, AttractionState, 
     if (params.demographicAttractionMultiplier && (params.concentrationSensitivity ?? 0) > 0) {
       errors.push('demographicAttractionMultiplier (diagnostic) cannot combine with concentrationSensitivity > 0');
     }
+    if (
+      (params.concentrationSensitivity ?? 0) > 0 &&
+      (params.wEngines ?? 0) + (params.wHuman ?? 0) <= 0
+    ) {
+      errors.push(
+        'wEngines + wHuman must be positive when concentrationSensitivity > 0',
+      );
+    }
     return { valid: errors.length === 0, errors, warnings: [] };
   },
 
@@ -272,7 +280,10 @@ export const attractionModule = defineModule<AttractionParams, AttractionState, 
       params.concentrationGrowthHigh, params.concentrationGrowthLow,
     );
     const freed = shift * (params.wRegen + params.wVitality);
-    const enginesSplit = params.wEngines / (params.wEngines + params.wHuman);
+    const institutionalWeight = params.wEngines + params.wHuman;
+    const enginesSplit = institutionalWeight > 0
+      ? params.wEngines / institutionalWeight
+      : 0.5;
     const wEngines = params.wEngines + enginesSplit * freed;
     const wHuman = params.wHuman + (1 - enginesSplit) * freed;
     const wHub = params.wHub * (1 + shift);

--- a/packages/tsimulation/CHANGELOG.md
+++ b/packages/tsimulation/CHANGELOG.md
@@ -38,6 +38,15 @@ onward. Before 1.0, minor versions may include breaking changes.
   concept of a connection between module ports.
 
 ### Added
+- First-class vintage stock, straight-line depreciable-vintage, and in-transit
+  ledgers with additions, delivery lags, scheduled retirements, scrappage,
+  terminal stocks, and conservation checks.
+- Unit-and-estimand-aware multiplication and division. High-risk equations
+  require a semantic derivation and reject undeclared same-unit inputs.
+- Complete-manifest integrity hashes and default verification of manifest,
+  input, output, data-lineage, and experiment hashes.
+- Value-vintage semantics plus completeness audits for population, geography,
+  totality, time, and ratio denominators.
 - `ModuleDefinition<TParams, TState, TInputs, TOutputs>` — what a module author
   writes, and `defineModule`'s new parameter type. It differs from `Module` only
   in that `inputs`/`outputs` are optional: `defineModule` derives them from
@@ -108,6 +117,12 @@ onward. Before 1.0, minor versions may include breaking changes.
   adapters, collectors, standalone models, calibration, and v2 run manifests.
 
 ### Changed (behavior)
+- Standalone model semantics and model-contract audits are strict by default.
+  `completeModelSemanticContracts()` provides an auditable migration path from
+  complete unit schemas without mutating shared port objects; explicit opt-out
+  remains available for infrastructure fixtures.
+- Two-factor interactions over larger factorials now require explicit
+  conditioning or balanced mean marginalization.
 - The engine now runs each module's `validate()` at load time, throwing on
   invalid params and warning on warnings. Previously `validate()` was never
   called by the engine — a module relying on it for enforcement would have let

--- a/packages/tsimulation/README.md
+++ b/packages/tsimulation/README.md
@@ -25,8 +25,9 @@ access, co-located parameter metadata — and brings them to TypeScript.
   wiring and runtime shape drift fail before results can escape the model.
 - **Meaning is checked separately from units.** Estimands declare population,
   geography, inclusion, total/incremental status, ratio basis, temporal support,
-  and valuation. Dataset-specific measurement regimes and explicit crosswalks
-  prevent equal-unit values from being treated as interchangeable.
+  value vintage, and valuation. Dataset-specific measurement regimes and
+  explicit crosswalks prevent equal-unit values from being treated as
+  interchangeable.
 - **One project, multiple time scales.** Annual systems, monthly networks, and
   event models share APIs without forcing every model into an annual module.
 - **Evidence-aware.** Development, validation, holdout, diagnostic, and scenario
@@ -105,7 +106,7 @@ standalone models; both distinguish dimensional leaves, metadata, structured
 schemas, and remaining opaque escape hatches.
 
 `opaquePort()` still exists for truly external or
-unbounded structures and require an explanation. They should be rare: a record
+unbounded structures and requires an explanation. It should be rare: a record
 containing several physical dimensions is normally a reason to use a recursive
 schema, not to make the record opaque.
 
@@ -134,6 +135,23 @@ assertUnitBalance('capital stock', unitQuantity(nextCapital, '$T'), [
 important identities and unit transitions rather than wrapping every scalar in
 the model.
 
+For equations where equal units can still hide different meanings, use
+`semanticQuantity()` with `multiplySemanticQuantities()` or
+`divideSemanticQuantities()`. These operations require a
+`SemanticDerivation`; every supplied estimand must match the derivation's
+declared inputs, so one dimensionless share cannot impersonate another.
+
+Reusable stock/flow ledgers keep lifecycle bookkeeping out of model-specific
+arrays:
+
+- `createVintageStock()` / `advanceVintageStock()` handle opening cohorts,
+  additions, delivery lags, scheduled retirements, scrappage, and terminal
+  stock with a checked conservation residual.
+- `depreciableVintage()` / `straightLineDepreciation()` keep deployment lags,
+  useful lives, depreciation, and terminal book value explicit.
+- `createTransitLedger()` / `advanceTransitLedger()` conserve dispatched,
+  arrived, and terminal in-transit inventory, including fractional delays.
+
 ## Semantic and measurement contracts
 
 Units answer “how is this number scaled?” They cannot tell total from
@@ -141,13 +159,24 @@ incremental electricity, residents from reporting hospitals, vessel counts
 from cargo volume, or a first release from a backfilled series.
 
 `EstimandContract` supplies the stable meaning of a quantity. Attach it with
-`measurementPort()`. Set semantic validation to
-`required` on a migrated model or adapter to reject any unannotated quantitative
-leaf.
+`measurementPort()`. Standalone models now default to `semanticValidation:
+'required'`: every quantitative leaf needs population, geography and boundary
+version, stock/flow/rate/share status, total-versus-incremental status,
+temporal support, and a value-vintage convention. Rates, shares, and indexes
+also require an explicit numerator and denominator.
+
+`completeModelSemanticContracts()` is a migration aid for a complete unit
+schema. It preserves authored contracts and fills missing leaves with
+path-specific, visibly framework-completed contracts before enforcing strict
+validation. Completion clones the port graph, preserving intentional sharing
+within the model without mutating schemas reused by another model.
+Domain-authored contracts remain preferable wherever the real population or
+reporting boundary is known. `semanticValidation: 'off'` is an explicit escape
+hatch for infrastructure fixtures, not the default.
 
 `MeasurementBinding` separately identifies the dataset, field, observation
 procedure, reporting coverage, release, and revision policy. Attach a
-source-bound observation with `observationPort()` or
+source-bound observation with `measurementPort()` or
 `observationPort()`. Two observation ports with different regimes fail
 compatibility unless they carry a matching `MeasurementCrosswalk`.
 
@@ -158,13 +187,20 @@ const admissions = defineEstimand({
   version: '1',
   quantityKind: 'health.covid-19.hospital-admissions',
   measure: { kind: 'flow', totality: 'total' },
-  population: { id: 'population.us.residents' },
-  geography: { id: 'geo.us' },
+  population: {
+    id: 'population.us.residents',
+    universe: 'People resident in the United States.',
+  },
+  geography: { id: 'geo.us', boundaryVersion: 'current-national-boundary' },
   time: {
     kind: 'interval',
     interval: 'epidemiological-week',
     aggregation: 'sum',
     calendar: 'cdc-week-ending-saturday',
+  },
+  vintage: {
+    basis: 'observation-release',
+    convention: 'CDC release associated with the bound measurement.',
   },
 });
 
@@ -204,7 +240,9 @@ and file resolvers are exported from `tsimulation/node`.
 
 `createRunManifest()` emits `tsimulation.run/v2`, linking snapshots,
 transformations, evidence, calibration splits, semantic lineage, experiment
-meaning, and input/output contract hashes. Parsed v1 manifests can be upgraded,
+meaning, and input/output contract hashes. It also seals the complete manifest
+payload with `integrityHash`; `parseRunManifest()` verifies that hash and all
+recomputable component hashes by default. Parsed v1 manifests can be upgraded,
 but unavailable historical lineage is explicitly marked rather than invented.
 
 ## Experiment meaning
@@ -223,6 +261,11 @@ This changes result language as well as metadata:
 - mixed studies must use `runNestedEnsemble()` and preserve an outer set of
   epistemic cases around inner aleatory distributions. A flat mixed ensemble
   throws instead of producing a misleading single CDF.
+
+`twoFactorInteraction()` refuses to select an arbitrary first level when a
+factorial has additional factors. Callers must condition on every extra factor
+or request mean marginalization; marginalization also requires balanced
+extra-factor support in all four comparison cells.
 
 ## Standalone models and experiments
 

--- a/packages/tsimulation/src/equation.ts
+++ b/packages/tsimulation/src/equation.ts
@@ -8,6 +8,14 @@ import {
   multiplyUnits,
   powUnit,
 } from './units.js';
+import {
+  assertEstimandComplete,
+  compareEstimands,
+  validateEstimand,
+  validateSemanticDerivation,
+  type EstimandContract,
+  type SemanticDerivation,
+} from './semantics.js';
 
 export interface UnitQuantity {
   value: number;
@@ -24,6 +32,10 @@ export interface UnitBalanceReport {
   tolerance: number;
 }
 
+export interface SemanticQuantity extends UnitQuantity {
+  estimand: EstimandContract;
+}
+
 function assertQuantity(quantity: UnitQuantity, context: string): void {
   if (!Number.isFinite(quantity.value)) throw new Error(`${context}: value must be finite`);
   if (!getUnit(quantity.unit)) throw new Error(`${context}: unknown unit '${quantity.unit}'`);
@@ -33,6 +45,141 @@ export function unitQuantity(value: number, unit: string, label?: string): UnitQ
   const result = { value, unit, ...(label ? { label } : {}) };
   assertQuantity(result, label ?? 'quantity');
   return result;
+}
+
+export function semanticQuantity(
+  value: number,
+  unit: string,
+  estimand: EstimandContract,
+  label?: string,
+): SemanticQuantity {
+  assertEstimandComplete(estimand, `${label ?? 'semantic quantity'} estimand`);
+  const quantity = unitQuantity(value, unit, label);
+  return { ...quantity, estimand };
+}
+
+export function convertSemanticQuantity(
+  quantity: SemanticQuantity,
+  targetUnit: string,
+): SemanticQuantity {
+  const converted = convertQuantity(quantity, targetUnit);
+  return { ...converted, estimand: quantity.estimand };
+}
+
+function assertDerivation(
+  inputs: readonly SemanticQuantity[],
+  outputEstimand: EstimandContract,
+  derivation: SemanticDerivation,
+  context: string,
+): void {
+  validateEstimand(outputEstimand, `${context} output estimand`);
+  validateSemanticDerivation(derivation, `${context} derivation`);
+  if (!compareEstimands(derivation.outputEstimand, outputEstimand).compatible) {
+    throw new Error(`${context}: derivation output does not match the equation output estimand`);
+  }
+  const declared = new Set(derivation.inputEstimandIds);
+  const supplied = new Set(inputs.map((input) => input.estimand.id));
+  for (const input of inputs) {
+    if (!declared.has(input.estimand.id)) {
+      throw new Error(
+        `${context}: derivation does not declare input estimand '${input.estimand.id}'`,
+      );
+    }
+  }
+  for (const inputId of declared) {
+    if (!supplied.has(inputId)) {
+      throw new Error(
+        `${context}: equation omits declared input estimand '${inputId}'`,
+      );
+    }
+  }
+}
+
+/**
+ * Multiplication with both dimensional and estimand checking. A changed
+ * estimand is explicit at the call site and may be backed by a registered
+ * SemanticDerivation.
+ */
+export function multiplySemanticQuantities(options: {
+  quantities: readonly SemanticQuantity[];
+  outputEstimand: EstimandContract;
+  targetUnit?: string;
+  derivation: SemanticDerivation;
+  label?: string;
+}): SemanticQuantity {
+  assertDerivation(
+    options.quantities,
+    options.outputEstimand,
+    options.derivation,
+    options.label ?? 'semantic product',
+  );
+  const product = multiplyQuantities(options.quantities, options.label);
+  const converted = options.targetUnit
+    ? convertQuantity(product, options.targetUnit)
+    : product;
+  return semanticQuantity(
+    converted.value,
+    converted.unit,
+    options.outputEstimand,
+    options.label,
+  );
+}
+
+export function divideSemanticQuantities(options: {
+  numerator: SemanticQuantity;
+  denominator: SemanticQuantity;
+  outputEstimand: EstimandContract;
+  targetUnit?: string;
+  derivation: SemanticDerivation;
+  label?: string;
+}): SemanticQuantity {
+  const inputs = [options.numerator, options.denominator];
+  assertDerivation(
+    inputs,
+    options.outputEstimand,
+    options.derivation,
+    options.label ?? 'semantic quotient',
+  );
+  const quotient = divideQuantities(
+    options.numerator,
+    options.denominator,
+    options.label,
+  );
+  const converted = options.targetUnit
+    ? convertQuantity(quotient, options.targetUnit)
+    : quotient;
+  return semanticQuantity(
+    converted.value,
+    converted.unit,
+    options.outputEstimand,
+    options.label,
+  );
+}
+
+/**
+ * Addition is only implicit for the same estimand. Combining different
+ * phenomena requires a separate explicit derivation rather than relying on
+ * unit compatibility alone.
+ */
+export function sumSemanticQuantities(
+  quantities: readonly SemanticQuantity[],
+  targetUnit = quantities[0]?.unit,
+  label?: string,
+): SemanticQuantity {
+  if (quantities.length === 0 || !targetUnit) {
+    throw new Error(`${label ?? 'semantic sum'} requires at least one quantity`);
+  }
+  const estimand = quantities[0].estimand;
+  for (const quantity of quantities.slice(1)) {
+    if (!compareEstimands(estimand, quantity.estimand).compatible) {
+      throw new Error(
+        `${label ?? 'semantic sum'}: cannot add different estimands ` +
+        `'${estimand.id}' and '${quantity.estimand.id}'`,
+      );
+    }
+  }
+  const summed = sumQuantities(quantities, targetUnit, label);
+  return semanticQuantity(summed.value, summed.unit, estimand, label);
 }
 
 export function convertQuantity(quantity: UnitQuantity, targetUnit: string): UnitQuantity {

--- a/packages/tsimulation/src/experiment.ts
+++ b/packages/tsimulation/src/experiment.ts
@@ -121,15 +121,105 @@ export function twoFactorInteraction<TInput, TOutput>(options: {
   controlB: string;
   treatmentB: string;
   outcome: (output: TOutput) => number;
+  /**
+   * Required for experiments with additional factors unless marginalize is
+   * selected. Every non-A/B factor must have an explicit conditioning level.
+   */
+  conditionOn?: Readonly<Record<string, string>>;
+  /** Average the four A×B cells over all matched levels of other factors. */
+  marginalize?: 'mean';
 }): TwoFactorInteraction {
-  const find = (a: string, b: string): number => {
-    const cell = options.experiment.cells.find((candidate) =>
-      candidate.levels[options.factorA] === a && candidate.levels[options.factorB] === b,
+  if (!options.experiment.factorNames.includes(options.factorA) ||
+      !options.experiment.factorNames.includes(options.factorB) ||
+      options.factorA === options.factorB) {
+    throw new Error('twoFactorInteraction requires two distinct experiment factors');
+  }
+  const otherFactors = options.experiment.factorNames.filter(
+    (factor) => factor !== options.factorA && factor !== options.factorB,
+  );
+  if (options.conditionOn && options.marginalize) {
+    throw new Error('Choose conditionOn or marginalize, not both');
+  }
+  if (
+    otherFactors.length > 0 &&
+    !options.marginalize &&
+    !otherFactors.every((factor) => options.conditionOn?.[factor] !== undefined)
+  ) {
+    throw new Error(
+      `Two-factor interaction is ambiguous with additional factors ` +
+      `[${otherFactors.join(', ')}]; supply conditionOn or marginalize: 'mean'`,
     );
-    if (!cell) throw new Error(`Missing factorial cell ${options.factorA}=${a}, ${options.factorB}=${b}`);
-    const value = options.outcome(cell.run.output);
-    if (!Number.isFinite(value)) throw new Error('Factorial outcome must be finite');
-    return value;
+  }
+  for (const factor of Object.keys(options.conditionOn ?? {})) {
+    if (!otherFactors.includes(factor)) {
+      throw new Error(`conditionOn references non-extra factor '${factor}'`);
+    }
+  }
+  const fullCellKeys = new Set<string>();
+  for (const cell of options.experiment.cells) {
+    const key = options.experiment.factorNames
+      .map((factor) => `${factor}=${cell.levels[factor]}`)
+      .join(',');
+    if (fullCellKeys.has(key)) {
+      throw new Error(`Factorial experiment has duplicate cell '${key}'`);
+    }
+    fullCellKeys.add(key);
+  }
+  if (options.marginalize && otherFactors.length > 0) {
+    const support = (a: string, b: string): string[] =>
+      options.experiment.cells
+        .filter((cell) =>
+          cell.levels[options.factorA] === a &&
+          cell.levels[options.factorB] === b
+        )
+        .map((cell) =>
+          otherFactors
+            .map((factor) => `${factor}=${cell.levels[factor]}`)
+            .join(','),
+        )
+        .sort();
+    const supports = [
+      support(options.controlA, options.controlB),
+      support(options.treatmentA, options.controlB),
+      support(options.controlA, options.treatmentB),
+      support(options.treatmentA, options.treatmentB),
+    ];
+    if (
+      supports[0].length === 0 ||
+      supports.some(
+        (candidate) =>
+          candidate.length !== supports[0].length ||
+          candidate.some((value, index) => value !== supports[0][index]),
+      )
+    ) {
+      throw new Error(
+        'Cannot marginalize a two-factor interaction over unbalanced extra-factor support',
+      );
+    }
+  }
+  const find = (a: string, b: string): number => {
+    const cells = options.experiment.cells.filter((candidate) =>
+      candidate.levels[options.factorA] === a &&
+      candidate.levels[options.factorB] === b &&
+      otherFactors.every((factor) =>
+        options.marginalize ||
+        candidate.levels[factor] === options.conditionOn?.[factor]
+      ),
+    );
+    if (cells.length === 0) {
+      throw new Error(`Missing factorial cell ${options.factorA}=${a}, ${options.factorB}=${b}`);
+    }
+    const values = cells.map((cell) => options.outcome(cell.run.output));
+    if (values.some((value) => !Number.isFinite(value))) {
+      throw new Error('Factorial outcome must be finite');
+    }
+    if (!options.marginalize && values.length !== 1) {
+      throw new Error(
+        `Conditioned factorial cell is not unique for ` +
+        `${options.factorA}=${a}, ${options.factorB}=${b}`,
+      );
+    }
+    return values.reduce((sum, value) => sum + value, 0) / values.length;
   };
   const control = find(options.controlA, options.controlB);
   const factorAOnly = find(options.treatmentA, options.controlB);

--- a/packages/tsimulation/src/index.ts
+++ b/packages/tsimulation/src/index.ts
@@ -29,6 +29,7 @@ export * from './ensemble.js';
 export * from './shock-ledger.js';
 export * from './manifest.js';
 export * from './liveness.js';
+export * from './stock-flow.js';
 export {
   assertCollectorContracts,
   auditCollectorContracts,

--- a/packages/tsimulation/src/manifest.ts
+++ b/packages/tsimulation/src/manifest.ts
@@ -92,11 +92,22 @@ export interface RunManifest<TInput = unknown, TOutput = unknown> {
     snapshotIds: readonly string[];
   };
   diagnostics?: Record<string, unknown>;
+  /** Hash of the complete manifest payload, excluding this field itself. */
+  integrityHash: string;
 }
 
 export type AnyRunManifest<TInput = unknown, TOutput = unknown> =
   | LegacyRunManifest<TInput, TOutput>
   | RunManifest<TInput, TOutput>;
+
+type UnsealedRunManifest<TInput, TOutput> =
+  Omit<RunManifest<TInput, TOutput>, 'integrityHash'>;
+
+function sealRunManifest<TInput, TOutput>(
+  payload: UnsealedRunManifest<TInput, TOutput>,
+): RunManifest<TInput, TOutput> {
+  return { ...payload, integrityHash: stableHash(payload) };
+}
 
 function validateSemanticLineage(
   lineage: ModelRun<unknown, unknown>['semanticLineage'],
@@ -149,9 +160,11 @@ export function createRunManifest<TInput, TOutput>(options: {
     transformations: options.transformations ?? [],
   };
   validateDataLineage(dataLineage);
-  const evidence = options.evidence ?? [];
+  const evidence = options.evidence ?? options.run.evidence;
+  const validationClaims =
+    options.validationClaims ?? options.run.validationClaims;
   validateEvidence(evidence, dataLineage.snapshots);
-  validateValidationClaims(options.validationClaims ?? [], evidence);
+  validateValidationClaims(validationClaims, evidence);
   if (options.experiment) validateExperiment(options.experiment, 'Manifest experiment');
   validateSemanticLineage(options.run.semanticLineage, 'Manifest run semantic lineage');
   const snapshotIds = new Set(dataLineage.snapshots.map((snapshot) => snapshot.id));
@@ -171,7 +184,7 @@ export function createRunManifest<TInput, TOutput>(options: {
       dataLineageHash,
       experiment: options.experiment,
     })}`;
-  return {
+  return sealRunManifest({
     schemaVersion: 'tsimulation.run/v2',
     runId,
     createdAt,
@@ -193,7 +206,7 @@ export function createRunManifest<TInput, TOutput>(options: {
     warnings: options.run.warnings,
     invariants: options.run.invariantReport,
     evidence,
-    validationClaims: options.validationClaims ?? [],
+    validationClaims,
     ...(options.experiment ? {
       experiment: {
         contract: options.experiment,
@@ -211,7 +224,7 @@ export function createRunManifest<TInput, TOutput>(options: {
       },
     } : {}),
     diagnostics: options.diagnostics,
-  };
+  });
 }
 
 /** Upgrade a parsed v1 record without pretending its unavailable lineage was captured. */
@@ -219,8 +232,14 @@ export function upgradeRunManifest<TInput, TOutput>(
   legacy: LegacyRunManifest<TInput, TOutput>,
 ): RunManifest<TInput, TOutput> {
   const dataLineage: DataLineage = { snapshots: [], transformations: [] };
-  const { calibration, ...base } = legacy;
-  return {
+  const {
+    calibration,
+    integrityHash: _legacyIntegrityHash,
+    ...base
+  } = legacy as LegacyRunManifest<TInput, TOutput> & {
+    integrityHash?: string;
+  };
+  return sealRunManifest({
     ...base,
     schemaVersion: 'tsimulation.run/v2',
     contractHashes: {
@@ -240,12 +259,12 @@ export function upgradeRunManifest<TInput, TOutput>(
         snapshotIds: [],
       },
     } : {}),
-  };
+  });
 }
 
 export function parseRunManifest(
   json: string,
-  options: { upgradeV1?: boolean } = {},
+  options: { upgradeV1?: boolean; verifyIntegrity?: boolean } = {},
 ): AnyRunManifest {
   const parsed = JSON.parse(json) as Partial<AnyRunManifest>;
   if (parsed.schemaVersion !== 'tsimulation.run/v1' &&
@@ -260,14 +279,113 @@ export function parseRunManifest(
   }
   if (parsed.schemaVersion === 'tsimulation.run/v2') {
     const current = parsed as RunManifest;
-    validateDataLineage(current.dataLineage);
-    validateEvidence(current.evidence ?? [], current.dataLineage.snapshots);
-    validateSemanticLineage(current.semanticLineage, 'Run manifest semantic lineage');
-    if (current.experiment) validateExperiment(current.experiment.contract);
-    return current;
+    return options.verifyIntegrity === false
+      ? validateRunManifestStructure(current)
+      : verifyRunManifest(current);
   }
   const legacy = parsed as LegacyRunManifest;
   return options.upgradeV1 === false ? legacy : upgradeRunManifest(legacy);
+}
+
+function requiredText(value: unknown, context: string): asserts value is string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`${context} must not be empty`);
+  }
+}
+
+function requiredHash(value: unknown, context: string): asserts value is string {
+  requiredText(value, context);
+  if (value !== 'legacy:unavailable' && !/^fnv1a32:[0-9a-f]{8}$/.test(value)) {
+    throw new Error(`${context} must be a stableHash value`);
+  }
+}
+
+function validateRunManifestStructure<TInput, TOutput>(
+  current: RunManifest<TInput, TOutput>,
+): RunManifest<TInput, TOutput> {
+  requiredText(current.model?.id, 'Run manifest model.id');
+  requiredText(current.model?.version, 'Run manifest model.version');
+  requiredHash(current.inputHash, 'Run manifest inputHash');
+  requiredHash(current.outputHash, 'Run manifest outputHash');
+  requiredHash(current.integrityHash, 'Run manifest integrityHash');
+  requiredHash(current.contractHashes?.input, 'Run manifest input contract hash');
+  requiredHash(current.contractHashes?.output, 'Run manifest output contract hash');
+  requiredHash(current.dataLineageHash, 'Run manifest dataLineageHash');
+  if (!Number.isFinite(current.durationMs) || current.durationMs < 0) {
+    throw new Error('Run manifest durationMs must be finite and non-negative');
+  }
+  if (!Array.isArray(current.warnings)) {
+    throw new Error('Run manifest warnings must be an array');
+  }
+  if (!current.invariants ||
+      !Array.isArray(current.invariants.errors) ||
+      !Array.isArray(current.invariants.warnings) ||
+      !Array.isArray(current.invariants.passed)) {
+    throw new Error('Run manifest invariants report is invalid');
+  }
+  validateDataLineage(current.dataLineage);
+  validateEvidence(current.evidence ?? [], current.dataLineage.snapshots);
+  validateValidationClaims(current.validationClaims ?? [], current.evidence ?? []);
+  validateSemanticLineage(current.semanticLineage, 'Run manifest semantic lineage');
+  for (const [id, hash] of Object.entries(current.dataHashes ?? {})) {
+    requiredText(id, 'Run manifest data hash ID');
+    requiredHash(hash, `Run manifest data hash '${id}'`);
+  }
+  if (current.experiment) {
+    validateExperiment(current.experiment.contract);
+    requiredHash(current.experiment.hash, 'Run manifest experiment hash');
+  }
+  const snapshotIds = new Set(
+    current.dataLineage.snapshots.map((snapshot) => snapshot.id),
+  );
+  for (const snapshotId of current.calibration?.snapshotIds ?? []) {
+    if (!snapshotIds.has(snapshotId)) {
+      throw new Error(
+        `Run manifest calibration references unknown snapshot '${snapshotId}'`,
+      );
+    }
+  }
+  return current;
+}
+
+/**
+ * Verify both schema and every hash whose source value is carried by the
+ * manifest. Contract and inline-data hashes are format-checked because their
+ * source contracts/data are intentionally external to the run record.
+ */
+export function verifyRunManifest<TInput, TOutput>(
+  manifest: RunManifest<TInput, TOutput>,
+): RunManifest<TInput, TOutput> {
+  const current = validateRunManifestStructure(manifest);
+  const checks: Array<[string, string, string]> = [
+    ['inputHash', current.inputHash, stableHash(current.input)],
+    ['outputHash', current.outputHash, stableHash(current.output)],
+    ['dataLineageHash', current.dataLineageHash, stableHash(current.dataLineage)],
+  ];
+  if (current.experiment) {
+    checks.push([
+      'experiment.hash',
+      current.experiment.hash,
+      stableHash(current.experiment.contract),
+    ]);
+  }
+  for (const [name, recorded, recomputed] of checks) {
+    if (recorded !== recomputed) {
+      throw new Error(
+        `Run manifest integrity failure for ${name}: ` +
+        `recorded ${recorded}, recomputed ${recomputed}`,
+      );
+    }
+  }
+  const { integrityHash, ...payload } = current;
+  const recomputedIntegrityHash = stableHash(payload);
+  if (integrityHash !== recomputedIntegrityHash) {
+    throw new Error(
+      `Run manifest integrity failure for integrityHash: ` +
+      `recorded ${integrityHash}, recomputed ${recomputedIntegrityHash}`,
+    );
+  }
+  return current;
 }
 
 export function manifestToJson(manifest: AnyRunManifest, space = 2): string {

--- a/packages/tsimulation/src/model.ts
+++ b/packages/tsimulation/src/model.ts
@@ -3,7 +3,11 @@ import type { EvidenceRecord, ValidationClaim } from './evidence.js';
 import { validateEvidence, validateValidationClaims } from './evidence.js';
 import type { Invariant, InvariantReport } from './validation.js';
 import { assertFiniteDeep, assertInvariants } from './validation.js';
-import type { PortContract, PortMeta } from './units.js';
+import type {
+  PortContract,
+  PortMeta,
+  QuantityPortMeta,
+} from './units.js';
 import {
   auditPortSemantics,
   assertPortContract,
@@ -77,6 +81,8 @@ export interface ModelRun<TInput, TOutput> {
     input: string;
     output: string;
   };
+  evidence: readonly EvidenceRecord[];
+  validationClaims: readonly ValidationClaim[];
   semanticLineage: {
     derivations: readonly { id: string; version: string }[];
     crosswalks: readonly { id: string; version: string }[];
@@ -95,6 +101,8 @@ export interface ModelContractAudit {
   semanticContracts: number;
   measurementContracts: number;
   missingSemanticPaths: string[];
+  incompleteSemanticPaths: string[];
+  semanticCompletenessErrors: string[];
 }
 
 export interface AuditableModelContract {
@@ -121,6 +129,8 @@ function walkModelContract(
       audit.semanticContracts += semantic.semanticContracts;
       audit.measurementContracts += semantic.measurementContracts;
       audit.missingSemanticPaths.push(...semantic.missingSemanticPaths);
+      audit.incompleteSemanticPaths.push(...semantic.incompleteSemanticPaths);
+      audit.semanticCompletenessErrors.push(...semantic.semanticCompletenessErrors);
     } catch (error) {
       audit.errors.push(error instanceof Error ? error.message : String(error));
     }
@@ -138,7 +148,7 @@ function walkModelContract(
 /** CI-friendly dimensional coverage audit for standalone model boundaries. */
 export function auditModelContracts(
   models: readonly AuditableModelContract[],
-  semanticValidation: SemanticValidationMode = 'if-present',
+  semanticValidation: SemanticValidationMode = 'required',
 ): ModelContractAudit {
   const audit: ModelContractAudit = {
     valid: true,
@@ -151,17 +161,284 @@ export function auditModelContracts(
     semanticContracts: 0,
     measurementContracts: 0,
     missingSemanticPaths: [],
+    incompleteSemanticPaths: [],
+    semanticCompletenessErrors: [],
   };
   for (const model of models) {
     walkModelContract(model.inputPorts, `model ${model.id}.input`, audit);
     walkModelContract(model.outputPorts, `model ${model.id}.output`, audit);
   }
   audit.missingSemanticPaths = [...new Set(audit.missingSemanticPaths)];
+  audit.incompleteSemanticPaths = [...new Set(audit.incompleteSemanticPaths)];
+  audit.semanticCompletenessErrors = [...new Set(audit.semanticCompletenessErrors)];
   if (semanticValidation === 'required') {
     audit.errors.push(...audit.missingSemanticPaths.map((path) => `${path}: missing estimand contract`));
+    audit.errors.push(...audit.semanticCompletenessErrors);
   }
   audit.valid = audit.errors.length === 0;
   return audit;
+}
+
+export interface SemanticBoundaryDefaults {
+  modelId: string;
+  modelVersion: string;
+  side: 'input' | 'output';
+}
+
+function semanticSlug(value: string): string {
+  return value
+    .replace(/^scenario[.[{]/i, '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '.')
+    .replace(/^\.+|\.+$/g, '') || 'value';
+}
+
+function inferMeasureKind(
+  path: string,
+  unit: string,
+): EstimandContract['measure']['kind'] {
+  const name = semanticSlug(path);
+  const explicitPerTime =
+    /\/(?:year|month|day|hour|quarter|week|yr|d)$/.test(unit);
+  if (unit === 'calendar-year' || unit === 'step-index') return 'index';
+  if (/index|multiple|multiplier|score|factor/.test(name)) return 'index';
+  if (explicitPerTime) {
+    return /^(?:hour|day|week|month|quarter|year)\//.test(unit)
+      ? 'count'
+      : unit === `fraction/${unit.split('/').at(-1)}` ||
+      unit === `1/${unit.split('/').at(-1)}` ||
+      /rate|growth|decay|elasticity|intensity/.test(name)
+      ? 'rate'
+      : 'flow';
+  }
+  if (unit === 'fraction' || unit === '%') return 'share';
+  if (
+    /share|fraction|probab|margin|uptime|utilization|availability|mix|weight|coverage|ratio/.test(name)
+  ) return 'share';
+  if (
+    /rate|growth|decay|elasticity|intensity|per-capita|[-.]per[-.]/.test(name)
+  ) return 'rate';
+  if (
+    /annual-sales|annual-units|revenue|expense|income|cash-flow|capex|depreciation|retirement|dispatch|arrival|shortfall/.test(name)
+  ) return 'flow';
+  if (/stock|inventory|storage|capacity|population|installed|bookvalue|intransit/.test(name)) {
+    return 'stock';
+  }
+  if (/(^|[.])counts?($|[.])|number-of|months-below|years-above/.test(name)) {
+    return 'count';
+  }
+  return 'level';
+}
+
+function inferInterval(path: string, unit: string): string | undefined {
+  for (const interval of ['quarter', 'month', 'week', 'day', 'hour', 'year'] as const) {
+    if (
+      unit.includes(`/${interval}`) ||
+      unit.includes(`${interval}^-1`) ||
+      path.toLowerCase().includes(`${interval}s[]`)
+    ) return interval === 'year' ? 'calendar-year' : `simulation-${interval}`;
+  }
+  if (/\/d(?:$|[)])/.test(unit) || unit === 'mb/d') return 'simulation-day';
+  if (/\/yr(?:$|[)])/.test(unit)) return 'calendar-year';
+  if (path.includes('[]')) return 'simulation-step';
+  return undefined;
+}
+
+function inferredEstimand(
+  path: string,
+  port: QuantityPortMeta,
+  defaults: SemanticBoundaryDefaults,
+): EstimandContract {
+  const canonicalPath = semanticSlug(path);
+  const kind = inferMeasureKind(path, port.unit);
+  const interval = inferInterval(path, port.unit);
+  const totality =
+    /increment|additional|newadoption|new-adoption|change|delta|shortfall|loss|added/.test(
+      canonicalPath,
+    )
+      ? 'incremental'
+      : 'total';
+  const aggregation =
+    kind === 'flow' || kind === 'count' ? 'sum' : 'mean';
+  const time: EstimandContract['time'] = interval
+    ? {
+        kind: 'interval',
+        interval,
+        aggregation,
+        calendar: interval === 'calendar-year' ? 'gregorian' : 'simulation-step',
+      }
+    : defaults.side === 'input'
+      ? { kind: 'timeless' }
+      : kind === 'stock' || kind === 'level' || kind === 'index'
+        ? { kind: 'instant', calendar: 'simulation-step' }
+        : {
+            kind: 'interval',
+            interval: 'simulation-horizon',
+            aggregation,
+            calendar: 'simulation-step',
+          };
+  const vintageBasis: NonNullable<EstimandContract['vintage']>['basis'] =
+    /opening|beginning|initial/.test(canonicalPath)
+      ? 'opening-stock'
+      : /ending|terminal/.test(canonicalPath)
+        ? 'closing-stock'
+        : defaults.side === 'input'
+          ? 'scenario-assumption'
+          : 'current-period';
+  return {
+    schemaVersion: 'tsimulation.estimand/v1',
+    id: `estimand.${semanticSlug(defaults.modelId)}.${canonicalPath}`,
+    version: defaults.modelVersion,
+    quantityKind: `simulation.${semanticSlug(defaults.modelId)}.${canonicalPath}`,
+    measure: {
+      kind,
+      totality,
+      accounting: /net|margin|balance|income|cashflow|cash-flow/.test(canonicalPath)
+        ? 'net'
+        : 'gross',
+    },
+    population: {
+      id: `population.${semanticSlug(defaults.modelId)}.${canonicalPath}`,
+      universe:
+        `Values represented by '${path}' within the ${defaults.modelId} modeled scenario boundary.`,
+    },
+    geography: {
+      id: `geo.${semanticSlug(defaults.modelId)}.scenario-boundary`,
+      boundaryVersion: `${defaults.modelId}-${defaults.modelVersion}`,
+    },
+    ...(kind === 'rate' || kind === 'share' || kind === 'index'
+      ? {
+          ratio: {
+            numerator: `${path} modeled numerator`,
+            denominator:
+              kind === 'share'
+                ? `${path} applicable modeled total`
+                : kind === 'rate'
+                  ? `${path} applicable exposure or time`
+                  : `${path} defined reference value`,
+          },
+        }
+      : {}),
+    time,
+    vintage: {
+      basis: vintageBasis,
+      convention:
+        vintageBasis === 'scenario-assumption'
+          ? 'scenario input as supplied for this run'
+          : 'simulation step associated with the boundary value',
+    },
+    description:
+      `Framework-completed boundary contract for ${defaults.modelId}.${path}.`,
+  };
+}
+
+function completeEstimand(
+  estimand: EstimandContract,
+  inferred: EstimandContract,
+): void {
+  estimand.measure = {
+    ...estimand.measure,
+    totality: estimand.measure.totality ?? inferred.measure.totality,
+    accounting: estimand.measure.accounting ?? inferred.measure.accounting,
+  };
+  estimand.population ??= inferred.population;
+  if (estimand.population && !estimand.population.universe) {
+    estimand.population = {
+      ...estimand.population,
+      universe: inferred.population!.universe,
+    };
+  }
+  estimand.geography ??= inferred.geography;
+  if (estimand.geography && !estimand.geography.boundaryVersion) {
+    estimand.geography = {
+      ...estimand.geography,
+      boundaryVersion: inferred.geography!.boundaryVersion,
+    };
+  }
+  if (
+    (estimand.measure.kind === 'rate' ||
+      estimand.measure.kind === 'share' ||
+      estimand.measure.kind === 'index') &&
+    !estimand.ratio
+  ) {
+    estimand.ratio = inferred.ratio ?? {
+      numerator: `${estimand.quantityKind} modeled numerator`,
+      denominator: `${estimand.quantityKind} defined reference value`,
+    };
+  }
+  estimand.time ??= inferred.time;
+  estimand.vintage ??= inferred.vintage;
+}
+
+function completeSemanticTree(
+  contract: unknown,
+  path: string,
+  defaults: SemanticBoundaryDefaults,
+): void {
+  if (isPortMeta(contract)) {
+    if (isQuantityPort(contract)) {
+      const inferred = inferredEstimand(path, contract, defaults);
+      if (contract.measurement) {
+        completeEstimand(contract.measurement.estimand, inferred);
+      }
+      if (contract.estimand) completeEstimand(contract.estimand, inferred);
+      else contract.estimand = contract.measurement?.estimand ?? inferred;
+      return;
+    }
+    if (isObjectPort(contract)) {
+      for (const [name, field] of Object.entries(
+        contract.fields as Readonly<Record<string, PortMeta>>,
+      )) {
+        completeSemanticTree(field, `${path}.${name}`, defaults);
+      }
+    } else if (isRecordPort(contract)) {
+      completeSemanticTree(contract.values, `${path}{value}`, defaults);
+    } else if (isVectorPort(contract)) {
+      completeSemanticTree(contract.items, `${path}[]`, defaults);
+    }
+    return;
+  }
+  if (typeof contract !== 'object' || contract === null) return;
+  for (const [name, field] of Object.entries(contract)) {
+    completeSemanticTree(field, name, defaults);
+  }
+}
+
+/**
+ * Complete every quantitative boundary leaf, preserving authored semantics
+ * and filling only missing fields. Intended for migrations: the resulting
+ * model is always strict and its generated contracts remain visible to audits.
+ */
+export function completeModelSemanticContracts<TInput, TOutput>(
+  definition: ModelDefinition<TInput, TOutput>,
+): ModelDefinition<TInput, TOutput> {
+  // Port schemas are commonly reused across models and between an input and
+  // an echoed output. Clone the whole semantic graph at once: this preserves
+  // intentional shared references within the definition while preventing one
+  // model's generated contracts from contaminating another definition.
+  const cloned = structuredClone({
+    inputPorts: definition.inputPorts,
+    outputPorts: definition.outputPorts,
+    semanticDerivations: definition.semanticDerivations,
+    semanticCrosswalks: definition.semanticCrosswalks,
+    measurementCrosswalks: definition.measurementCrosswalks,
+  });
+  completeSemanticTree(cloned.inputPorts, '', {
+    modelId: definition.id,
+    modelVersion: definition.version,
+    side: 'input',
+  });
+  completeSemanticTree(cloned.outputPorts, '', {
+    modelId: definition.id,
+    modelVersion: definition.version,
+    side: 'output',
+  });
+  return {
+    ...definition,
+    ...cloned,
+    semanticValidation: 'required',
+  };
 }
 
 function applyValidation(result: ValidationResult | void, context: string, warnings: string[]): void {
@@ -223,7 +500,8 @@ export function defineModel<TInput, TOutput>(
       validatePortMeta(port, `Model '${definition.id}' ${side} port '${name}'`);
     }
   }
-  if (definition.semanticValidation === 'required') {
+  const semanticValidation = definition.semanticValidation ?? 'required';
+  if (semanticValidation === 'required') {
     const semanticAudit = auditModelContracts([definition], 'required');
     if (!semanticAudit.valid) {
       throw new Error(
@@ -238,6 +516,13 @@ export function defineModel<TInput, TOutput>(
   const inputMeasurements = collectBoundaryMeasurements(definition.inputPorts);
   const outputMeasurements = collectBoundaryMeasurements(definition.outputPorts);
   const semanticIds = new Set<string>();
+  const availableDerivationInputs = new Set(
+    inputEstimands.map((estimand) => estimand.id),
+  );
+  const derivationDependencyIds = new Set(
+    (definition.semanticDerivations ?? [])
+      .flatMap((derivation) => derivation.inputEstimandIds),
+  );
   for (const derivation of definition.semanticDerivations ?? []) {
     validateSemanticDerivation(
       derivation,
@@ -247,21 +532,25 @@ export function defineModel<TInput, TOutput>(
       throw new Error(`Model '${definition.id}' has duplicate semantic lineage ID '${derivation.id}'`);
     }
     for (const inputId of derivation.inputEstimandIds) {
-      if (!inputEstimands.some((estimand) => estimand.id === inputId)) {
+      if (!availableDerivationInputs.has(inputId)) {
         throw new Error(
           `Model '${definition.id}' derivation '${derivation.id}' references input ` +
-          `estimand '${inputId}' that is absent from its input ports`,
+          `estimand '${inputId}' that is absent from its input ports and prior derivations`,
         );
       }
     }
-    if (!outputEstimands.some((estimand) =>
-      compareEstimands(estimand, derivation.outputEstimand).compatible
-    )) {
+    if (
+      !outputEstimands.some((estimand) =>
+        compareEstimands(estimand, derivation.outputEstimand).compatible
+      ) &&
+      !derivationDependencyIds.has(derivation.outputEstimand.id)
+    ) {
       throw new Error(
-        `Model '${definition.id}' derivation '${derivation.id}' output is absent from its ` +
-        'output ports',
+        `Model '${definition.id}' derivation '${derivation.id}' output is neither exposed ` +
+        'by an output port nor consumed by another derivation',
       );
     }
+    availableDerivationInputs.add(derivation.outputEstimand.id);
     semanticIds.add(derivation.id);
   }
   for (const crosswalk of definition.semanticCrosswalks ?? []) {
@@ -304,7 +593,7 @@ export function defineModel<TInput, TOutput>(
     }
     semanticIds.add(crosswalk.id);
   }
-  return definition;
+  return { ...definition, semanticValidation };
 }
 
 export function runModel<TInput, TOutput>(
@@ -340,6 +629,8 @@ export function runModel<TInput, TOutput>(
       input: stableHash(model.inputPorts),
       output: stableHash(model.outputPorts),
     },
+    evidence: model.evidence ?? [],
+    validationClaims: model.validationClaims ?? [],
     semanticLineage: {
       derivations: (model.semanticDerivations ?? []).map(({ id, version }) => ({
         id,

--- a/packages/tsimulation/src/semantics.ts
+++ b/packages/tsimulation/src/semantics.ts
@@ -91,6 +91,24 @@ export interface ValuationContract {
   exchangeRateBasis?: 'market' | 'ppp' | (string & {});
 }
 
+/**
+ * Declares which temporal vintage a modeled value represents. This is
+ * separate from temporal support: a calendar-year flow can be a current
+ * observation, a scenario assumption, or a cohort-vintage projection.
+ */
+export interface VintageContract {
+  basis:
+    | 'current-period'
+    | 'opening-stock'
+    | 'closing-stock'
+    | 'cohort'
+    | 'scenario-assumption'
+    | 'observation-release'
+    | 'structural-constant';
+  convention: string;
+  reference?: string;
+}
+
 export interface EstimandContract {
   schemaVersion: 'tsimulation.estimand/v1';
   /** Stable identifier for this estimand definition. */
@@ -104,6 +122,7 @@ export interface EstimandContract {
   geography?: GeographyContract;
   ratio?: RatioContract;
   time?: TemporalSupport;
+  vintage?: VintageContract;
   valuation?: ValuationContract;
   signConvention?: string;
   description?: string;
@@ -227,6 +246,11 @@ export interface EstimandComparison {
   targetHash: string;
 }
 
+export interface EstimandCompletenessIssue {
+  path: string;
+  message: string;
+}
+
 export interface MeasurementComparison {
   compatible: boolean;
   differences: readonly SemanticDifference[];
@@ -241,6 +265,7 @@ const MACHINE_FIELDS = [
   'geography',
   'ratio',
   'time',
+  'vintage',
   'valuation',
   'signConvention',
 ] as const;
@@ -318,6 +343,23 @@ export function validateEstimand(contract: EstimandContract, context = 'estimand
       requiredText(contract.geography.boundaryVersion, `${context}.geography.boundaryVersion`);
     }
   }
+  if (contract.vintage) {
+    if (!([
+      'current-period',
+      'opening-stock',
+      'closing-stock',
+      'cohort',
+      'scenario-assumption',
+      'observation-release',
+      'structural-constant',
+    ] as const).includes(contract.vintage.basis)) {
+      throw new Error(`${context}.vintage.basis is invalid`);
+    }
+    requiredText(contract.vintage.convention, `${context}.vintage.convention`);
+    if (contract.vintage.reference !== undefined) {
+      requiredText(contract.vintage.reference, `${context}.vintage.reference`);
+    }
+  }
   if (contract.ratio) {
     requiredText(contract.ratio.numerator, `${context}.ratio.numerator`);
     requiredText(contract.ratio.denominator, `${context}.ratio.denominator`);
@@ -336,6 +378,68 @@ export function validateEstimand(contract: EstimandContract, context = 'estimand
         (!Number.isInteger(contract.valuation.priceYear) || contract.valuation.priceYear < 0)) {
       throw new Error(`${context}.valuation.priceYear must be a non-negative integer`);
     }
+  }
+}
+
+/**
+ * Audit whether an estimand is specific enough to connect without guessing.
+ * Basic validation deliberately remains separate so a partially authored
+ * contract can be constructed and then completed at a model boundary.
+ */
+export function auditEstimandCompleteness(
+  contract: EstimandContract,
+  context = 'estimand',
+): readonly EstimandCompletenessIssue[] {
+  validateEstimand(contract, context);
+  const issues: EstimandCompletenessIssue[] = [];
+  const missing = (path: string, message: string): void => {
+    issues.push({ path: `${context}.${path}`, message });
+  };
+  if (!contract.population) {
+    missing('population', 'population boundary is required');
+  } else if (!contract.population.universe?.trim()) {
+    missing('population.universe', 'population universe is required');
+  }
+  if (!contract.geography) {
+    missing('geography', 'geography boundary is required');
+  } else if (!contract.geography.boundaryVersion?.trim()) {
+    missing('geography.boundaryVersion', 'geography boundary vintage is required');
+  }
+  if (contract.measure.totality === undefined) {
+    missing('measure.totality', 'total-versus-incremental status is required');
+  }
+  if (
+    (contract.measure.kind === 'rate' ||
+      contract.measure.kind === 'share' ||
+      contract.measure.kind === 'index') &&
+    !contract.ratio
+  ) {
+    missing('ratio', 'numerator and denominator are required for a rate, share, or index');
+  }
+  if (!contract.time) {
+    missing('time', 'temporal support is required');
+  } else if (
+    contract.time.kind !== 'timeless' &&
+    !contract.time.calendar?.trim()
+  ) {
+    missing('time.calendar', 'calendar convention is required');
+  }
+  if (!contract.vintage) {
+    missing('vintage', 'value-vintage convention is required');
+  }
+  return issues;
+}
+
+export function assertEstimandComplete(
+  contract: EstimandContract,
+  context = 'estimand',
+): void {
+  const issues = auditEstimandCompleteness(contract, context);
+  if (issues.length > 0) {
+    throw new Error(
+      `${context} is incomplete:\n` +
+      issues.map((issue) => `- ${issue.path}: ${issue.message}`).join('\n'),
+    );
   }
 }
 

--- a/packages/tsimulation/src/stock-flow.ts
+++ b/packages/tsimulation/src/stock-flow.ts
@@ -1,0 +1,471 @@
+/**
+ * First-class stock/flow primitives for physical and financial vintages.
+ *
+ * The framework deliberately keeps quantities numeric at model boundaries,
+ * but state transitions that mix additions, retirements, scrappage, delivery
+ * lags, and terminal stocks should not be reimplemented ad hoc in every model.
+ */
+
+import { getUnit } from './units.js';
+
+const EPSILON = 1e-12;
+
+function finiteNonNegative(value: number, context: string): void {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${context} must be finite and non-negative`);
+  }
+}
+
+function integer(value: number, context: string, min = 0): void {
+  if (!Number.isInteger(value) || value < min) {
+    throw new Error(`${context} must be an integer >= ${min}`);
+  }
+}
+
+function validUnit(unit: string, context: string): void {
+  if (!getUnit(unit)) throw new Error(`${context} has unknown unit '${unit}'`);
+}
+
+export type InitialRetirementProfile = 'uniform' | 'bullet';
+
+export interface VintageCohort {
+  id: string;
+  vintageStep: number;
+  inServiceStep: number;
+  retirementStep: number;
+  originalAmount: number;
+  remainingAmount: number;
+}
+
+export interface VintageStockState {
+  unit: string;
+  lastStep: number;
+  cohorts: readonly VintageCohort[];
+  cumulativeAdditions: number;
+  cumulativeDeliveries: number;
+  cumulativeScheduledRetirements: number;
+  cumulativeScrappage: number;
+}
+
+export interface VintageStockAdvance {
+  state: VintageStockState;
+  openingStock: number;
+  additions: number;
+  deliveries: number;
+  scheduledRetirements: number;
+  scrappage: number;
+  closingStock: number;
+  terminalStock: number;
+  terminalInTransit: number;
+  conservationResidual: number;
+}
+
+export function activeVintageStock(
+  state: VintageStockState,
+  step = state.lastStep,
+): number {
+  return state.cohorts.reduce((sum, cohort) =>
+    cohort.inServiceStep <= step && cohort.retirementStep > step
+      ? sum + cohort.remainingAmount
+      : sum, 0);
+}
+
+export function inTransitVintageStock(
+  state: VintageStockState,
+  step = state.lastStep,
+): number {
+  return state.cohorts.reduce((sum, cohort) =>
+    cohort.inServiceStep > step ? sum + cohort.remainingAmount : sum, 0);
+}
+
+/** Return the active stock scheduled to retire in the next named step. */
+export function scheduledVintageRetirements(
+  state: VintageStockState,
+  step = state.lastStep + 1,
+): number {
+  integer(step, 'step');
+  if (step <= state.lastStep) {
+    throw new Error(
+      `Scheduled-retirement step must be after ${state.lastStep}, got ${step}`,
+    );
+  }
+  return state.cohorts.reduce((sum, cohort) =>
+    cohort.remainingAmount > 0 &&
+    cohort.inServiceStep <= state.lastStep &&
+    cohort.retirementStep <= step
+      ? sum + cohort.remainingAmount
+      : sum, 0);
+}
+
+/**
+ * Create an opening stock. A uniform legacy profile retires equal slices at
+ * steps startStep..startStep+life-1, matching the common assumption that the
+ * unknown opening fleet is uniformly distributed across ages.
+ */
+export function createVintageStock(options: {
+  unit: string;
+  initialStock?: number;
+  serviceLifeSteps: number;
+  startStep?: number;
+  initialRetirementProfile?: InitialRetirementProfile;
+  idPrefix?: string;
+}): VintageStockState {
+  validUnit(options.unit, 'Vintage stock');
+  const initialStock = options.initialStock ?? 0;
+  const startStep = options.startStep ?? 0;
+  const profile = options.initialRetirementProfile ?? 'uniform';
+  finiteNonNegative(initialStock, 'initialStock');
+  integer(options.serviceLifeSteps, 'serviceLifeSteps', 1);
+  integer(startStep, 'startStep');
+  if (profile !== 'uniform' && profile !== 'bullet') {
+    throw new Error(
+      `initialRetirementProfile must be 'uniform' or 'bullet', got '${String(profile)}'`,
+    );
+  }
+  const cohorts: VintageCohort[] = [];
+  if (initialStock > 0 && profile === 'uniform') {
+    const amount = initialStock / options.serviceLifeSteps;
+    for (let remainingLife = 1; remainingLife <= options.serviceLifeSteps; remainingLife++) {
+      cohorts.push({
+        id: `${options.idPrefix ?? 'legacy'}-${remainingLife}`,
+        vintageStep: startStep - (options.serviceLifeSteps - remainingLife),
+        inServiceStep: Number.MIN_SAFE_INTEGER,
+        retirementStep: startStep + remainingLife - 1,
+        originalAmount: amount,
+        remainingAmount: amount,
+      });
+    }
+  } else if (initialStock > 0) {
+    cohorts.push({
+      id: `${options.idPrefix ?? 'legacy'}-bullet`,
+      vintageStep: startStep,
+      inServiceStep: Number.MIN_SAFE_INTEGER,
+      retirementStep: startStep + options.serviceLifeSteps - 1,
+      originalAmount: initialStock,
+      remainingAmount: initialStock,
+    });
+  }
+  return {
+    unit: options.unit,
+    lastStep: startStep - 1,
+    cohorts,
+    cumulativeAdditions: 0,
+    cumulativeDeliveries: 0,
+    cumulativeScheduledRetirements: 0,
+    cumulativeScrappage: 0,
+  };
+}
+
+/**
+ * Advance one consecutive step. Scheduled retirement is a beginning-of-step
+ * flow; deliveries and immediate additions then enter service; scrappage is
+ * applied pro rata to the surviving active fleet.
+ */
+export function advanceVintageStock(
+  state: VintageStockState,
+  options: {
+    step: number;
+    additions?: number;
+    serviceLifeSteps: number;
+    inServiceDelaySteps?: number;
+    scrappageAmount?: number;
+    scrappageFraction?: number;
+    cohortId?: string;
+  },
+): VintageStockAdvance {
+  validUnit(state.unit, 'Vintage stock state');
+  integer(options.step, 'step');
+  if (options.step !== state.lastStep + 1) {
+    throw new Error(
+      `Vintage stock step must be consecutive: expected ${state.lastStep + 1}, got ${options.step}`,
+    );
+  }
+  integer(options.serviceLifeSteps, 'serviceLifeSteps', 1);
+  const delay = options.inServiceDelaySteps ?? 0;
+  integer(delay, 'inServiceDelaySteps');
+  const additions = options.additions ?? 0;
+  const requestedScrappage = options.scrappageAmount ?? 0;
+  const scrappageFraction = options.scrappageFraction ?? 0;
+  finiteNonNegative(additions, 'additions');
+  finiteNonNegative(requestedScrappage, 'scrappageAmount');
+  if (!Number.isFinite(scrappageFraction) || scrappageFraction < 0 || scrappageFraction > 1) {
+    throw new Error('scrappageFraction must be finite and in [0,1]');
+  }
+  if (requestedScrappage > 0 && scrappageFraction > 0) {
+    throw new Error('Specify scrappageAmount or scrappageFraction, not both');
+  }
+
+  const openingStock = activeVintageStock(state);
+  const nextCohorts = state.cohorts.map((cohort) => ({ ...cohort }));
+  let scheduledRetirements = 0;
+  let deliveries = 0;
+
+  for (const cohort of nextCohorts) {
+    const wasActive = cohort.inServiceStep <= state.lastStep;
+    if (wasActive && cohort.retirementStep <= options.step) {
+      scheduledRetirements += cohort.remainingAmount;
+      cohort.remainingAmount = 0;
+    } else if (
+      cohort.remainingAmount > 0 &&
+      cohort.inServiceStep > state.lastStep &&
+      cohort.inServiceStep <= options.step
+    ) {
+      deliveries += cohort.remainingAmount;
+    }
+  }
+
+  if (additions > 0) {
+    const inServiceStep = options.step + delay;
+    nextCohorts.push({
+      id: options.cohortId ?? `vintage-${options.step}-${nextCohorts.length}`,
+      vintageStep: options.step,
+      inServiceStep,
+      retirementStep: inServiceStep + options.serviceLifeSteps,
+      originalAmount: additions,
+      remainingAmount: additions,
+    });
+    if (delay === 0) deliveries += additions;
+  }
+
+  const activeBeforeScrappage = nextCohorts.reduce((sum, cohort) =>
+    cohort.remainingAmount > 0 &&
+    cohort.inServiceStep <= options.step &&
+    cohort.retirementStep > options.step
+      ? sum + cohort.remainingAmount
+      : sum, 0);
+  const scrappage = Math.min(
+    activeBeforeScrappage,
+    requestedScrappage > 0
+      ? requestedScrappage
+      : activeBeforeScrappage * scrappageFraction,
+  );
+  if (scrappage > 0 && activeBeforeScrappage > 0) {
+    const retention = 1 - scrappage / activeBeforeScrappage;
+    for (const cohort of nextCohorts) {
+      if (
+        cohort.inServiceStep <= options.step &&
+        cohort.retirementStep > options.step
+      ) {
+        cohort.remainingAmount *= retention;
+      }
+    }
+  }
+
+  const cohorts = nextCohorts.filter((cohort) =>
+    cohort.remainingAmount > EPSILON && cohort.retirementStep > options.step);
+  const nextState: VintageStockState = {
+    unit: state.unit,
+    lastStep: options.step,
+    cohorts,
+    cumulativeAdditions: state.cumulativeAdditions + additions,
+    cumulativeDeliveries: state.cumulativeDeliveries + deliveries,
+    cumulativeScheduledRetirements:
+      state.cumulativeScheduledRetirements + scheduledRetirements,
+    cumulativeScrappage: state.cumulativeScrappage + scrappage,
+  };
+  const closingStock = activeVintageStock(nextState);
+  const terminalInTransit = inTransitVintageStock(nextState);
+  const conservationResidual =
+    closingStock - (openingStock + deliveries - scheduledRetirements - scrappage);
+  const tolerance = 1e-9 * Math.max(1, openingStock, deliveries, closingStock);
+  if (Math.abs(conservationResidual) > tolerance) {
+    throw new Error(
+      `Vintage stock conservation failed: residual=${conservationResidual} ${state.unit}`,
+    );
+  }
+  return {
+    state: nextState,
+    openingStock,
+    additions,
+    deliveries,
+    scheduledRetirements,
+    scrappage,
+    closingStock,
+    terminalStock: closingStock,
+    terminalInTransit,
+    conservationResidual,
+  };
+}
+
+export interface DepreciableVintage {
+  id: string;
+  expenditureStep: number;
+  inServiceStep: number;
+  cost: number;
+  usefulLifeSteps: number;
+  salvageValue?: number;
+}
+
+export interface DepreciationSnapshot {
+  step: number;
+  depreciation: number;
+  accumulatedDepreciation: number;
+  endingBookValue: number;
+  grossBookValue: number;
+}
+
+export function depreciableVintage(options: DepreciableVintage): DepreciableVintage {
+  integer(options.expenditureStep, 'expenditureStep');
+  integer(options.inServiceStep, 'inServiceStep');
+  integer(options.usefulLifeSteps, 'usefulLifeSteps', 1);
+  if (options.inServiceStep < options.expenditureStep) {
+    throw new Error('inServiceStep cannot precede expenditureStep');
+  }
+  finiteNonNegative(options.cost, 'cost');
+  finiteNonNegative(options.salvageValue ?? 0, 'salvageValue');
+  if ((options.salvageValue ?? 0) > options.cost) {
+    throw new Error('salvageValue cannot exceed cost');
+  }
+  if (!options.id.trim()) throw new Error('Depreciable vintage ID must not be empty');
+  return { ...options };
+}
+
+/** Straight-line book depreciation for explicit in-service vintages. */
+export function straightLineDepreciation(
+  vintages: readonly DepreciableVintage[],
+  step: number,
+): DepreciationSnapshot {
+  integer(step, 'step');
+  let depreciation = 0;
+  let accumulatedDepreciation = 0;
+  let grossBookValue = 0;
+  for (const raw of vintages) {
+    const vintage = depreciableVintage(raw);
+    if (vintage.expenditureStep > step) continue;
+    grossBookValue += vintage.cost;
+    const basis = vintage.cost - (vintage.salvageValue ?? 0);
+    const perStep = basis / vintage.usefulLifeSteps;
+    const elapsed = Math.max(0, step - vintage.inServiceStep + 1);
+    const depreciatedSteps = Math.min(vintage.usefulLifeSteps, elapsed);
+    accumulatedDepreciation += perStep * depreciatedSteps;
+    if (step >= vintage.inServiceStep &&
+        step < vintage.inServiceStep + vintage.usefulLifeSteps) {
+      depreciation += perStep;
+    }
+  }
+  return {
+    step,
+    depreciation,
+    accumulatedDepreciation,
+    endingBookValue: Math.max(0, grossBookValue - accumulatedDepreciation),
+    grossBookValue,
+  };
+}
+
+export interface TransitBatch {
+  id: string;
+  dispatchStep: number;
+  deliveryStep: number;
+  amount: number;
+}
+
+export interface TransitLedgerState {
+  unit: string;
+  lastStep: number;
+  batches: readonly TransitBatch[];
+  cumulativeDispatches: number;
+  cumulativeArrivals: number;
+}
+
+export interface TransitAdvance {
+  state: TransitLedgerState;
+  dispatched: number;
+  arrived: number;
+  terminalInTransit: number;
+  conservationResidual: number;
+}
+
+export function createTransitLedger(unit: string, startStep = 0): TransitLedgerState {
+  validUnit(unit, 'Transit ledger');
+  integer(startStep, 'startStep');
+  return {
+    unit,
+    lastStep: startStep - 1,
+    batches: [],
+    cumulativeDispatches: 0,
+    cumulativeArrivals: 0,
+  };
+}
+
+/**
+ * Advance a transit queue with an optional fractional delay. Fractional
+ * delivery is linearly split across the adjacent discrete steps.
+ */
+export function advanceTransitLedger(
+  state: TransitLedgerState,
+  options: {
+    step: number;
+    dispatchAmount?: number;
+    delaySteps: number;
+    batchId?: string;
+  },
+): TransitAdvance {
+  validUnit(state.unit, 'Transit ledger state');
+  integer(options.step, 'step');
+  if (options.step !== state.lastStep + 1) {
+    throw new Error(
+      `Transit step must be consecutive: expected ${state.lastStep + 1}, got ${options.step}`,
+    );
+  }
+  const dispatched = options.dispatchAmount ?? 0;
+  finiteNonNegative(dispatched, 'dispatchAmount');
+  if (!Number.isFinite(options.delaySteps) || options.delaySteps < 0) {
+    throw new Error('delaySteps must be finite and non-negative');
+  }
+
+  const batches = state.batches.map((batch) => ({ ...batch }));
+  if (dispatched > 0) {
+    const floor = Math.floor(options.delaySteps);
+    const remainder = options.delaySteps - floor;
+    const firstAmount = dispatched * (1 - remainder);
+    const secondAmount = dispatched * remainder;
+    if (firstAmount > EPSILON) {
+      batches.push({
+        id: `${options.batchId ?? `transit-${options.step}`}-a`,
+        dispatchStep: options.step,
+        deliveryStep: options.step + floor,
+        amount: firstAmount,
+      });
+    }
+    if (secondAmount > EPSILON) {
+      batches.push({
+        id: `${options.batchId ?? `transit-${options.step}`}-b`,
+        dispatchStep: options.step,
+        deliveryStep: options.step + floor + 1,
+        amount: secondAmount,
+      });
+    }
+  }
+
+  let arrived = 0;
+  const pending: TransitBatch[] = [];
+  for (const batch of batches) {
+    if (batch.deliveryStep <= options.step) arrived += batch.amount;
+    else pending.push(batch);
+  }
+  const nextState: TransitLedgerState = {
+    unit: state.unit,
+    lastStep: options.step,
+    batches: pending,
+    cumulativeDispatches: state.cumulativeDispatches + dispatched,
+    cumulativeArrivals: state.cumulativeArrivals + arrived,
+  };
+  const terminalInTransit = pending.reduce((sum, batch) => sum + batch.amount, 0);
+  const conservationResidual =
+    nextState.cumulativeDispatches -
+    nextState.cumulativeArrivals -
+    terminalInTransit;
+  const tolerance = 1e-9 * Math.max(1, nextState.cumulativeDispatches);
+  if (Math.abs(conservationResidual) > tolerance) {
+    throw new Error(
+      `Transit conservation failed: residual=${conservationResidual} ${state.unit}`,
+    );
+  }
+  return {
+    state: nextState,
+    dispatched,
+    arrived,
+    terminalInTransit,
+    conservationResidual,
+  };
+}

--- a/packages/tsimulation/src/units.ts
+++ b/packages/tsimulation/src/units.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  auditEstimandCompleteness,
   assertEstimandsCompatible,
   assertMeasurementsCompatible,
   validateEstimand,
@@ -989,6 +990,8 @@ export interface SemanticSchemaAudit {
   semanticContracts: number;
   measurementContracts: number;
   missingSemanticPaths: string[];
+  incompleteSemanticPaths: string[];
+  semanticCompletenessErrors: string[];
 }
 
 function walkSemanticSchema(
@@ -998,8 +1001,15 @@ function walkSemanticSchema(
 ): void {
   if (isQuantityPort(meta)) {
     audit.quantitativeContracts++;
-    if (meta.estimand) audit.semanticContracts++;
-    else audit.missingSemanticPaths.push(path);
+    if (meta.estimand) {
+      audit.semanticContracts++;
+      for (const issue of auditEstimandCompleteness(meta.estimand, path)) {
+        audit.incompleteSemanticPaths.push(issue.path);
+        audit.semanticCompletenessErrors.push(`${issue.path}: ${issue.message}`);
+      }
+    } else {
+      audit.missingSemanticPaths.push(path);
+    }
     if (meta.measurement) audit.measurementContracts++;
     return;
   }
@@ -1021,6 +1031,8 @@ export function auditPortSemantics(meta: PortMeta, path = 'port'): SemanticSchem
     semanticContracts: 0,
     measurementContracts: 0,
     missingSemanticPaths: [],
+    incompleteSemanticPaths: [],
+    semanticCompletenessErrors: [],
   };
   walkSemanticSchema(meta, path, audit);
   return audit;

--- a/packages/tsimulation/test/modeling-layer.test.ts
+++ b/packages/tsimulation/test/modeling-layer.test.ts
@@ -3,15 +3,20 @@ import assert from 'node:assert/strict';
 import {
   ModelRegistry,
   calibrate,
+  completeModelSemanticContracts,
   createRunManifest,
+  defineEstimand,
   defineModel,
   inferValidationGrade,
   manifestToJson,
+  parseRunManifest,
   runFactorial,
   runModel,
   runScenarios,
   twoFactorInteraction,
+  unitPort,
   validateEvidence,
+  type QuantityPortMeta,
 } from '../src/index.js';
 
 const arithmetic = defineModel<{ a: number; b: number }, { y: number }>({
@@ -21,6 +26,7 @@ const arithmetic = defineModel<{ a: number; b: number }, { y: number }>({
   run: ({ a, b }) => ({ y: a + b + a * b }),
   inputPorts: { a: { unit: '1' }, b: { unit: '1' } },
   outputPorts: { y: { unit: '1' } },
+  semanticValidation: 'off',
   invariants: [{ id: 'finite-y', description: 'y is finite', check: (row) => Number.isFinite(row.y) }],
 });
 
@@ -30,10 +36,12 @@ test('model runner enforces finite values, invariants, and registry uniqueness',
   assert.throws(() => defineModel<{ x: number }, { y: number }>({
     id: 'bad-unit', version: '1', description: 'bad', run: ({ x }) => ({ y: x }),
     inputPorts: { x: { unit: 'not-a-unit' } }, outputPorts: { y: { unit: '1' } },
+    semanticValidation: 'off',
   }), /unknown unit/);
   assert.throws(() => defineModel<{ x: number }, { y: number }>({
     id: 'bad-evidence', version: '1', description: 'bad', run: ({ x }) => ({ y: x }),
     inputPorts: { x: { unit: '1' } }, outputPorts: { y: { unit: '1' } },
+    semanticValidation: 'off',
     validationClaims: [{
       grade: 'scenario-only', label: 'Claim', basis: 'Basis', evidenceIds: ['missing'],
     }],
@@ -41,6 +49,106 @@ test('model runner enforces finite values, invariants, and registry uniqueness',
   const registry = new ModelRegistry().register(arithmetic);
   assert.equal(registry.get('arithmetic'), arithmetic);
   assert.throws(() => registry.register(arithmetic), /already registered/);
+});
+
+test('model semantics are mandatory unless an infrastructure test opts out', () => {
+  assert.throws(
+    () => defineModel<{ x: number }, { y: number }>({
+      id: 'missing-semantics',
+      version: '1',
+      description: 'Must not silently accept unit-only quantitative ports.',
+      inputPorts: { x: { unit: '1' } },
+      outputPorts: { y: { unit: '1' } },
+      run: ({ x }) => ({ y: x }),
+    }),
+    /missing estimand contract/,
+  );
+  const incomplete = defineEstimand({
+    schemaVersion: 'tsimulation.estimand/v1',
+    id: 'estimand.test.incomplete',
+    version: '1',
+    quantityKind: 'test.incomplete',
+    measure: { kind: 'share' },
+  });
+  assert.throws(
+    () => defineModel<{ x: number }, { y: number }>({
+      id: 'incomplete-semantics',
+      version: '1',
+      description: 'A present but underspecified estimand is still invalid.',
+      inputPorts: { x: { unit: 'fraction', estimand: incomplete } },
+      outputPorts: { y: { unit: 'fraction', estimand: incomplete } },
+      run: ({ x }) => ({ y: x }),
+    }),
+    /population boundary is required.*total-versus-incremental status is required/s,
+  );
+});
+
+test('semantic completion distinguishes stocks, flows, shares, and per-capacity rates', () => {
+  type Input = {
+    firmCapacity: number;
+    dailyGasFlow: number;
+    coverage: number;
+    annualValue: number;
+    capexPerAddedCapacity: number;
+  };
+  const completed = completeModelSemanticContracts<Input, Input>({
+    id: 'semantic-inference',
+    version: '1',
+    description: 'Adversarial semantic-inference fixture.',
+    inputPorts: {
+      firmCapacity: { unit: 'GW' },
+      dailyGasFlow: { unit: 'Bcf/day' },
+      coverage: { unit: 'fraction' },
+      annualValue: { unit: '$B/year' },
+      capexPerAddedCapacity: { unit: '$/(driveunit/year)' },
+    },
+    outputPorts: {
+      firmCapacity: { unit: 'GW' },
+      dailyGasFlow: { unit: 'Bcf/day' },
+      coverage: { unit: 'fraction' },
+      annualValue: { unit: '$B/year' },
+      capexPerAddedCapacity: { unit: '$/(driveunit/year)' },
+    },
+    run: (input) => input,
+  });
+  const kind = (name: keyof Input) =>
+    (completed.inputPorts[name] as QuantityPortMeta).estimand!.measure.kind;
+  assert.equal(kind('firmCapacity'), 'stock');
+  assert.equal(kind('dailyGasFlow'), 'flow');
+  assert.equal(kind('coverage'), 'share');
+  assert.equal(kind('annualValue'), 'flow');
+  assert.equal(kind('capexPerAddedCapacity'), 'rate');
+  assert.doesNotThrow(() => defineModel(completed));
+});
+
+test('semantic completion cannot leak generated meaning through reused port schemas', () => {
+  const shared = unitPort('GW');
+  const first = completeModelSemanticContracts({
+    id: 'first-completion',
+    version: '1.0.0',
+    description: 'First completion boundary.',
+    run: (input: { capacity: number }) => input,
+    inputPorts: { capacity: shared },
+    outputPorts: { capacity: shared },
+  });
+  const second = completeModelSemanticContracts({
+    id: 'second-completion',
+    version: '1.0.0',
+    description: 'Second completion boundary.',
+    run: (input: { capacity: number }) => input,
+    inputPorts: { capacity: shared },
+    outputPorts: { capacity: shared },
+  });
+
+  assert.equal(shared.estimand, undefined);
+  assert.notEqual(
+    (first.inputPorts as { capacity: typeof shared }).capacity.estimand?.id,
+    (second.inputPorts as { capacity: typeof shared }).capacity.estimand?.id,
+  );
+  assert.equal(
+    (first.inputPorts as { capacity: typeof shared }).capacity.estimand,
+    (first.outputPorts as { capacity: typeof shared }).capacity.estimand,
+  );
 });
 
 test('calibration selects on development data before revealing holdout', () => {
@@ -90,6 +198,85 @@ test('factorial experiments expose a genuine difference-in-differences interacti
   ]), /Duplicate scenario/);
 });
 
+test('two-factor interactions cannot silently select the first level of a third factor', () => {
+  const model = defineModel<{ a: number; b: number; c: number }, { y: number }>({
+    id: 'three-factor',
+    version: '1',
+    description: 'Third-factor interaction diagnostic.',
+    run: ({ a, b, c }) => ({ y: a * b * c }),
+    inputPorts: {
+      a: { unit: '1' },
+      b: { unit: '1' },
+      c: { unit: '1' },
+    },
+    outputPorts: { y: { unit: '1' } },
+    semanticValidation: 'off',
+  });
+  const experiment = runFactorial({
+    model,
+    baseInput: { a: 0, b: 0, c: 1 },
+    factors: {
+      a: [
+        { id: 'off', apply: (input) => ({ ...input, a: 0 }) },
+        { id: 'on', apply: (input) => ({ ...input, a: 1 }) },
+      ],
+      b: [
+        { id: 'off', apply: (input) => ({ ...input, b: 0 }) },
+        { id: 'on', apply: (input) => ({ ...input, b: 1 }) },
+      ],
+      c: [
+        { id: 'low', apply: (input) => ({ ...input, c: 1 }) },
+        { id: 'high', apply: (input) => ({ ...input, c: 10 }) },
+      ],
+    },
+  });
+  const interactionOptions = {
+    experiment,
+    factorA: 'a',
+    factorB: 'b',
+    controlA: 'off',
+    treatmentA: 'on',
+    controlB: 'off',
+    treatmentB: 'on',
+    outcome: (output: { y: number }) => output.y,
+  };
+  assert.throws(
+    () => twoFactorInteraction(interactionOptions),
+    /ambiguous with additional factors/,
+  );
+  assert.equal(twoFactorInteraction({
+    ...interactionOptions,
+    conditionOn: { c: 'low' },
+  }).interaction, 1);
+  assert.equal(twoFactorInteraction({
+    ...interactionOptions,
+    conditionOn: { c: 'high' },
+  }).interaction, 10);
+  assert.equal(twoFactorInteraction({
+    ...interactionOptions,
+    marginalize: 'mean',
+  }).interaction, 5.5);
+  const unbalanced = {
+    ...experiment,
+    cells: experiment.cells.filter(
+      (cell) =>
+        !(
+          cell.levels.a === 'on' &&
+          cell.levels.b === 'on' &&
+          cell.levels.c === 'high'
+        ),
+    ),
+  };
+  assert.throws(
+    () => twoFactorInteraction({
+      ...interactionOptions,
+      experiment: unbalanced,
+      marginalize: 'mean',
+    }),
+    /unbalanced extra-factor support/,
+  );
+});
+
 test('run manifests are stable, auditable, and carry evidence roles', () => {
   const evidence = [{
     id: 'observed-holdout',
@@ -112,4 +299,23 @@ test('run manifests are stable, auditable, and carry evidence roles', () => {
   assert.equal(manifestToJson(first), manifestToJson(second));
   assert.equal(first.inputHash, second.inputHash);
   assert.equal(first.dataHashes.fixture, second.dataHashes.fixture);
+  assert.equal(first.integrityHash, second.integrityHash);
+  const tampered = structuredClone(first);
+  tampered.output.y = 999;
+  assert.throws(
+    () => parseRunManifest(JSON.stringify(tampered)),
+    /integrity failure for outputHash/,
+  );
+  const tamperedLineage = structuredClone(first);
+  tamperedLineage.semanticLineage = {
+    ...tamperedLineage.semanticLineage,
+    derivations: [
+      ...tamperedLineage.semanticLineage.derivations,
+      { id: 'forged-derivation', version: '1' },
+    ],
+  };
+  assert.throws(
+    () => parseRunManifest(JSON.stringify(tamperedLineage)),
+    /integrity failure for integrityHash/,
+  );
 });

--- a/packages/tsimulation/test/numerics-experiments.test.ts
+++ b/packages/tsimulation/test/numerics-experiments.test.ts
@@ -60,6 +60,7 @@ test('thresholds, parameter audits, and seeded ensembles are reproducible', () =
     id: 'ensemble-test', version: '1', description: 'test', run: ({ x }) => ({ y: x * x }),
     inputPorts: { x: { unit: '1' }, inert: { unit: '1', optional: true } },
     outputPorts: { y: { unit: '1' } },
+    semanticValidation: 'off',
   });
   const audit = auditParameterEffects({
     model, baseline: { x: 2 },

--- a/packages/tsimulation/test/semantic-equation.test.ts
+++ b/packages/tsimulation/test/semantic-equation.test.ts
@@ -1,0 +1,154 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  defineEstimand,
+  defineSemanticDerivation,
+  divideSemanticQuantities,
+  multiplySemanticQuantities,
+  semanticQuantity,
+  sumSemanticQuantities,
+} from '../src/index.js';
+
+const scope = {
+  population: {
+    id: 'population.test',
+    universe: 'Test population.',
+  },
+  geography: {
+    id: 'geo.test',
+    boundaryVersion: 'v1',
+  },
+  time: {
+    kind: 'interval' as const,
+    interval: 'simulation-step',
+    aggregation: 'mean' as const,
+    calendar: 'simulation-step',
+  },
+  vintage: {
+    basis: 'current-period' as const,
+    convention: 'Value applies to the current simulation step.',
+  },
+};
+
+const power = defineEstimand({
+  schemaVersion: 'tsimulation.estimand/v1',
+  id: 'estimand.test.power',
+  version: '1',
+  quantityKind: 'electricity.power',
+  measure: { kind: 'level', totality: 'incremental' },
+  ...scope,
+});
+const hours = defineEstimand({
+  schemaVersion: 'tsimulation.estimand/v1',
+  id: 'estimand.test.hours',
+  version: '1',
+  quantityKind: 'calendar.hours',
+  measure: { kind: 'count', totality: 'total' },
+  ...scope,
+});
+const energy = defineEstimand({
+  schemaVersion: 'tsimulation.estimand/v1',
+  id: 'estimand.test.energy',
+  version: '1',
+  quantityKind: 'electricity.energy',
+  measure: { kind: 'flow', totality: 'incremental' },
+  ...scope,
+});
+const otherEnergy = defineEstimand({
+  ...energy,
+  id: 'estimand.test.other-energy',
+  quantityKind: 'electricity.other-energy',
+});
+const powerTimesHours = defineSemanticDerivation({
+  schemaVersion: 'tsimulation.derivation/v1',
+  id: 'derivation.test.power-times-hours',
+  version: '1',
+  description: 'Integrate power over time.',
+  inputEstimandIds: [power.id, hours.id],
+  outputEstimand: energy,
+  expression: 'energy = power * hours',
+});
+const energyPerHours = defineSemanticDerivation({
+  schemaVersion: 'tsimulation.derivation/v1',
+  id: 'derivation.test.energy-per-hours',
+  version: '1',
+  description: 'Recover average power from energy and time.',
+  inputEstimandIds: [energy.id, hours.id],
+  outputEstimand: power,
+  expression: 'power = energy / hours',
+});
+
+test('semantic equations enforce both units and output meaning', () => {
+  const result = multiplySemanticQuantities({
+    quantities: [
+      semanticQuantity(2, 'GW', power),
+      semanticQuantity(1, 'hour', hours),
+    ],
+    outputEstimand: energy,
+    derivation: powerTimesHours,
+    targetUnit: 'GWh',
+  });
+  assert.equal(result.value, 2);
+  assert.equal(result.unit, 'GWh');
+  assert.equal(result.estimand.id, energy.id);
+
+  const recovered = divideSemanticQuantities({
+    numerator: result,
+    denominator: semanticQuantity(1, 'hour', hours),
+    outputEstimand: power,
+    derivation: energyPerHours,
+    targetUnit: 'GW',
+  });
+  assert.equal(recovered.value, 2);
+});
+
+test('same-unit values with different estimands cannot be added implicitly', () => {
+  assert.throws(() => sumSemanticQuantities([
+    semanticQuantity(1, 'GWh', energy),
+    semanticQuantity(1, 'GWh', otherEnergy),
+  ]), /different estimands/);
+});
+
+test('same-unit dimensionless inputs cannot impersonate one another in an equation', () => {
+  const loadFactor = defineEstimand({
+    schemaVersion: 'tsimulation.estimand/v1',
+    id: 'estimand.test.load-factor',
+    version: '1',
+    quantityKind: 'electricity.load-factor',
+    measure: { kind: 'share', totality: 'total' },
+    ratio: { numerator: 'average load', denominator: 'maximum load' },
+    ...scope,
+  });
+  const energyShare = defineEstimand({
+    ...loadFactor,
+    id: 'estimand.test.energy-share',
+    quantityKind: 'electricity.energy-share',
+    ratio: { numerator: 'selected energy', denominator: 'total energy' },
+  });
+  const realizedPower = defineEstimand({
+    ...power,
+    id: 'estimand.test.realized-power',
+    quantityKind: 'electricity.realized-power',
+  });
+  const derivation = defineSemanticDerivation({
+    schemaVersion: 'tsimulation.derivation/v1',
+    id: 'derivation.test.realized-power',
+    version: '1',
+    description: 'Apply load factor to maximum power.',
+    inputEstimandIds: [power.id, loadFactor.id],
+    outputEstimand: realizedPower,
+    expression: 'realizedPower = power * loadFactor',
+  });
+  assert.throws(
+    () => multiplySemanticQuantities({
+      quantities: [
+        semanticQuantity(2, 'GW', power),
+        semanticQuantity(0.5, 'fraction', energyShare),
+      ],
+      outputEstimand: realizedPower,
+      derivation,
+      targetUnit: 'GW',
+    }),
+    /does not declare input estimand 'estimand\.test\.energy-share'/,
+  );
+});

--- a/packages/tsimulation/test/semantics-provenance-study.test.ts
+++ b/packages/tsimulation/test/semantics-provenance-study.test.ts
@@ -38,6 +38,7 @@ const totalSiteEnergy = defineEstimand({
   measure: { kind: 'flow', totality: 'total' },
   population: {
     id: 'facilities.us-data-centers',
+    universe: 'United States data-center facilities and their full-site electricity use.',
     inclusion: ['servers', 'cooling', 'power conversion'],
   },
   geography: { id: 'geo.us', boundaryVersion: '2020' },
@@ -46,6 +47,10 @@ const totalSiteEnergy = defineEstimand({
     interval: 'calendar-year',
     aggregation: 'sum',
     calendar: 'gregorian',
+  },
+  vintage: {
+    basis: 'current-period',
+    convention: 'Calendar year to which the reported energy flow applies.',
   },
 });
 
@@ -57,6 +62,7 @@ const incrementalServerEnergy = defineEstimand({
   measure: { kind: 'flow', totality: 'incremental' },
   population: {
     id: 'facilities.us-data-centers',
+    universe: 'United States data-center server equipment and its incremental electricity use.',
     inclusion: ['servers'],
     exclusion: ['cooling', 'power conversion'],
   },
@@ -66,6 +72,10 @@ const incrementalServerEnergy = defineEstimand({
     interval: 'calendar-year',
     aggregation: 'sum',
     calendar: 'gregorian',
+  },
+  vintage: {
+    basis: 'current-period',
+    convention: 'Calendar year to which the reported energy flow applies.',
   },
 });
 
@@ -417,6 +427,7 @@ const squareModel = defineModel<{ x: number }, { y: number }>({
   description: 'Study semantics test model.',
   inputPorts: { x: { unit: '1' } },
   outputPorts: { y: { unit: '1' } },
+  semanticValidation: 'off',
   run: ({ x }) => ({ y: x * x }),
 });
 

--- a/packages/tsimulation/test/stock-flow.test.ts
+++ b/packages/tsimulation/test/stock-flow.test.ts
@@ -1,0 +1,147 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  advanceTransitLedger,
+  advanceVintageStock,
+  createTransitLedger,
+  createVintageStock,
+  depreciableVintage,
+  straightLineDepreciation,
+} from '../src/index.js';
+
+test('vintage stock retires a new cohort at exactly its service life', () => {
+  let state = createVintageStock({
+    unit: 'GW',
+    initialStock: 0,
+    serviceLifeSteps: 2,
+  });
+  const rows = [];
+  for (let step = 0; step < 4; step++) {
+    const result = advanceVintageStock(state, {
+      step,
+      additions: step === 0 ? 10 : 0,
+      serviceLifeSteps: 2,
+    });
+    state = result.state;
+    rows.push(result);
+  }
+  assert.equal(rows[0].closingStock, 10);
+  assert.equal(rows[1].closingStock, 10);
+  assert.equal(rows[2].scheduledRetirements, 10);
+  assert.equal(rows[2].closingStock, 0);
+  assert.ok(rows.every((row) => Math.abs(row.conservationResidual) < 1e-12));
+});
+
+test('uniform opening vintage retires evenly and scrappage reconciles', () => {
+  let state = createVintageStock({
+    unit: 'ebike',
+    initialStock: 40,
+    serviceLifeSteps: 4,
+    initialRetirementProfile: 'uniform',
+  });
+  const first = advanceVintageStock(state, {
+    step: 0,
+    additions: 5,
+    serviceLifeSteps: 4,
+    scrappageAmount: 3,
+  });
+  state = first.state;
+  assert.equal(first.openingStock, 40);
+  assert.equal(first.scheduledRetirements, 10);
+  assert.equal(first.deliveries, 5);
+  assert.equal(first.scrappage, 3);
+  assert.equal(first.closingStock, 32);
+  assert.equal(first.terminalStock, 32);
+  assert.equal(state.cumulativeScrappage, 3);
+});
+
+test('vintage stock rejects fractional service lives and skipped steps', () => {
+  const state = createVintageStock({
+    unit: 'GW',
+    serviceLifeSteps: 2,
+  });
+  assert.throws(() => advanceVintageStock(state, {
+    step: 0,
+    additions: 1,
+    serviceLifeSteps: 2.5,
+  }), /integer/);
+  assert.throws(() => advanceVintageStock(state, {
+    step: 1,
+    additions: 1,
+    serviceLifeSteps: 2,
+  }), /consecutive/);
+});
+
+test('straight-line depreciation respects deployment lag and terminal book value', () => {
+  const vintage = depreciableVintage({
+    id: 'chips-0',
+    expenditureStep: 0,
+    inServiceStep: 2,
+    cost: 16,
+    usefulLifeSteps: 4,
+  });
+  assert.equal(straightLineDepreciation([vintage], 1).depreciation, 0);
+  assert.equal(straightLineDepreciation([vintage], 2).depreciation, 4);
+  assert.equal(straightLineDepreciation([vintage], 5).endingBookValue, 0);
+  assert.equal(straightLineDepreciation([vintage], 6).depreciation, 0);
+});
+
+test('depreciation excludes unspent future vintages and rejects service before spend', () => {
+  const future = depreciableVintage({
+    id: 'future-build',
+    expenditureStep: 3,
+    inServiceStep: 4,
+    cost: 120,
+    usefulLifeSteps: 3,
+  });
+  assert.deepEqual(straightLineDepreciation([future], 2), {
+    step: 2,
+    depreciation: 0,
+    accumulatedDepreciation: 0,
+    endingBookValue: 0,
+    grossBookValue: 0,
+  });
+  assert.equal(straightLineDepreciation([future], 3).endingBookValue, 120);
+  assert.throws(
+    () => depreciableVintage({
+      id: 'time-travel-build',
+      expenditureStep: 3,
+      inServiceStep: 2,
+      cost: 120,
+      usefulLifeSteps: 3,
+    }),
+    /inServiceStep cannot precede expenditureStep/,
+  );
+});
+
+test('opening vintage profiles fail closed at runtime', () => {
+  assert.throws(
+    () => createVintageStock({
+      unit: 'GW',
+      initialStock: 10,
+      serviceLifeSteps: 20,
+      initialRetirementProfile: 'triangular' as 'uniform',
+    }),
+    /initialRetirementProfile must be 'uniform' or 'bullet'/,
+  );
+});
+
+test('transit ledger preserves fractional-delay cargo and exposes terminal stock', () => {
+  let state = createTransitLedger('million-barrel');
+  const first = advanceTransitLedger(state, {
+    step: 0,
+    dispatchAmount: 30,
+    delaySteps: 1.5,
+  });
+  state = first.state;
+  assert.equal(first.arrived, 0);
+  assert.equal(first.terminalInTransit, 30);
+  const second = advanceTransitLedger(state, { step: 1, delaySteps: 1.5 });
+  state = second.state;
+  assert.equal(second.arrived, 15);
+  assert.equal(second.terminalInTransit, 15);
+  const third = advanceTransitLedger(state, { step: 2, delaySteps: 1.5 });
+  assert.equal(third.arrived, 15);
+  assert.equal(third.terminalInTransit, 0);
+  assert.equal(third.conservationResidual, 0);
+});

--- a/packages/tsimulation/test/units-shocks-adapters.test.ts
+++ b/packages/tsimulation/test/units-shocks-adapters.test.ts
@@ -283,6 +283,7 @@ test('model contracts catch runtime drift beyond the declared TypeScript shape',
   const model = defineModel<{ x: number }, { y: number }>({
     id: 'drifting-model', version: '1', description: 'returns an undeclared field',
     inputPorts: { x: { unit: '1' } }, outputPorts: { y: { unit: '1' } },
+    semanticValidation: 'off',
     run: ({ x }) => ({ y: x, accidental: x } as { y: number }),
   });
   assert.throws(() => runModel(model, { x: 1 }), /accidental: value has no port contract/);

--- a/src/modules/energy.test.ts
+++ b/src/modules/energy.test.ts
@@ -800,6 +800,42 @@ test('validation catches negative minWACC', () => {
   expect(result.valid).toBe(false);
 });
 
+test('new capacity retires at exactly its declared integer lifetime', () => {
+  const params = energyModule.mergeParams({
+    lifetime: { ...energyDefaults.lifetime, solar: 2 },
+  });
+  let state = energyModule.init(params);
+  const cohortId = 'oecd-solar-2025';
+  for (let yearIndex = 0; yearIndex <= 2; yearIndex++) {
+    const result = energyModule.step(
+      state,
+      createInputs(100_000, 1_000),
+      params,
+      2025 + yearIndex,
+      yearIndex,
+    );
+    state = result.state;
+    if (yearIndex === 0) {
+      const cohort = state.regional.oecd.solar.vintages.cohorts.find(
+        (candidate) => candidate.id === cohortId,
+      );
+      expect(cohort !== undefined).toBeTrue();
+      expect(cohort?.retirementStep).toBe(2);
+    }
+  }
+  expect(
+    state.regional.oecd.solar.vintages.cohorts.some(
+      (cohort) => cohort.id === cohortId,
+    ),
+  ).toBeFalse();
+});
+
+test('fractional asset lifetimes are rejected before array/vintage accounting', () => {
+  expect(energyModule.validate({
+    lifetime: { ...energyDefaults.lifetime, solar: 2.5 },
+  }).valid).toBeFalse();
+});
+
 // =============================================================================
 // SUMMARY
 // =============================================================================

--- a/src/modules/energy.ts
+++ b/src/modules/energy.ts
@@ -24,7 +24,16 @@
  * - cumulativeCapacity: Total deployed (for learning curves)
  */
 
-import { defineModule, Module, ValidationResult, validatedMerge, unitPort } from 'tsimulation';
+import {
+  advanceVintageStock,
+  createVintageStock,
+  defineModule,
+  type Module,
+  type ValidationResult,
+  type VintageStockState,
+  validatedMerge,
+  unitPort,
+} from 'tsimulation';
 import {
   ENERGY_ADDITION_PORT,
   ENERGY_CAPACITY_PORT,
@@ -523,8 +532,9 @@ export const energyDefaults: EnergyParams = {
 /** Regional capacity state (per region, per source) */
 export interface RegionalCapacityState {
   installed: number;      // Current capacity (GW or GWh) in this region
-  additions: number[];    // History of additions (for retirement)
-  initialCapacity: number; // Original 2025 capacity (for retirement)
+  additions: number[];    // Auditable history of annual additions
+  initialCapacity: number; // Original 2025 capacity
+  vintages: VintageStockState;
 }
 
 /** Global learning state (per source) - for Wright's Law */
@@ -924,6 +934,7 @@ export const energyModule: Module<
       ...energyDefaults,
       ...params,
       eroi: { ...energyDefaults.eroi, ...(params.eroi ?? {}) },
+      lifetime: { ...energyDefaults.lifetime, ...(params.lifetime ?? {}) },
     };
 
     // Validate regional carbon prices
@@ -966,6 +977,10 @@ export const energyModule: Module<
       }
       if (s.cost0 < 0) {
         errors.push(`sources.${source}.cost0 cannot be negative`);
+      }
+      const lifetime = p.lifetime[source];
+      if (!Number.isInteger(lifetime) || lifetime < 1) {
+        errors.push(`lifetime.${source} must be an integer number of years >= 1`);
       }
       const eroi = p.eroi[source];
       if (eroi !== undefined && eroi <= 1) {
@@ -1111,8 +1126,15 @@ export const energyModule: Module<
         const cap2025 = params.sources[source].capacity2025[region];
         regional[region][source] = {
           installed: cap2025,
-          additions: [0], // Year 0 has no additions
+          additions: [],
           initialCapacity: cap2025,
+          vintages: createVintageStock({
+            unit: source === 'battery' ? 'GWh' : 'GW',
+            initialStock: cap2025,
+            serviceLifeSteps: params.lifetime[source],
+            initialRetirementProfile: 'uniform',
+            idPrefix: `${region}-${source}-opening`,
+          }),
         };
       }
     }
@@ -1510,25 +1532,21 @@ export const energyModule: Module<
       // Calculate retirements and update regional state
       for (const source of ENERGY_SOURCES) {
         const regionState = state.regional[region][source];
-        const prevInstalled = regionState.installed;
-
         const addition = fundedAdditions[source];
         const lifetime = params.lifetime[source];
-        let retirement = 0;
-
-        if (yearIndex < lifetime) {
-          retirement += regionState.initialCapacity / lifetime;
-        }
-        if (yearIndex >= lifetime && regionState.additions.length > lifetime) {
-          retirement += regionState.additions[yearIndex - lifetime] || 0;
-        }
-
-        const newInstalled = Math.max(0, prevInstalled + addition - retirement);
+        const vintage = advanceVintageStock(regionState.vintages, {
+          step: yearIndex,
+          additions: addition,
+          serviceLifeSteps: lifetime,
+          cohortId: `${region}-${source}-${year}`,
+        });
+        const newInstalled = vintage.closingStock;
 
         newRegional[region][source] = {
           installed: newInstalled,
           additions: [...regionState.additions, addition],
           initialCapacity: regionState.initialCapacity,
+          vintages: vintage.state,
         };
 
         regionalCapacities[region][source] = newInstalled;

--- a/src/simulations/critical-materials/critical-materials.test.ts
+++ b/src/simulations/critical-materials/critical-materials.test.ts
@@ -104,4 +104,26 @@ test('empty dynamic supply paths are rejected rather than treated as normal supp
   })).toThrow("Supply path 'rare-earths' must not be empty");
 });
 
+test('omitted curtailment threshold executes the same 0.98 default that validation uses', () => {
+  const options = {
+    months: 6,
+    revision: 'v2' as const,
+    supplyPaths: {
+      'rare-earths': [0.8, 0.8, 0.8, 0.8, 0.8, 0.8],
+    },
+    priceElasticity: 1,
+    pricePassThrough: 1,
+  };
+  const implicit = simulateDynamicNetwork(criticalMaterialNetwork, options);
+  const explicit = simulateDynamicNetwork(criticalMaterialNetwork, {
+    ...options,
+    curtailmentThreshold: 0.98,
+  });
+  expect(implicit.firstCurtailmentMonth).toBe(explicit.firstCurtailmentMonth);
+  expect(implicit.cumulativeWeightedOutputLoss).toBeCloseTo(
+    explicit.cumulativeWeightedOutputLoss,
+    12,
+  );
+});
+
 printSummary();

--- a/src/simulations/critical-materials/dynamic-network.ts
+++ b/src/simulations/critical-materials/dynamic-network.ts
@@ -199,7 +199,7 @@ export function simulateDynamicNetwork(
     const measuredOutput = curtailmentNode
       ? outputRatios[curtailmentNode] ?? 1
       : weightedFinalOutput;
-    const threshold = options.curtailmentThreshold ?? 0.95;
+    const threshold = options.curtailmentThreshold ?? 0.98;
     if (firstCurtailmentMonth === null && measuredOutput < threshold) {
       firstCurtailmentMonth = month;
     } else if (

--- a/src/simulations/critical-materials/hormuz-data.ts
+++ b/src/simulations/critical-materials/hormuz-data.ts
@@ -91,6 +91,12 @@ export interface HormuzRegionExposure {
 export interface HormuzModelParams {
   oil: OilMarketParams;
   lng: TradedCommodityParams;
+  /**
+   * Total world natural-gas consumption, including pipeline and domestic gas.
+   * LNG-market shortages must be divided by this denominator before they are
+   * applied to total regional gas consumption.
+   */
+  globalGasDemandPerDay: number;
   fertilizer: FertilizerMarketParams;
   regions: Readonly<Record<Region, HormuzRegionExposure>>;
   /** Converts LNG spot-market prices into a broad regional gas-price shock. */
@@ -146,6 +152,10 @@ export const hormuzDefaults: HormuzModelParams = {
     routeRiskPremium: 0.07,
     maxPriceMultiple: 5,
   },
+  // Rough 2025 world natural-gas use in Bcf/day. The LNG subsystem above
+  // clears the much smaller seaborne market; this separate denominator keeps
+  // a seaborne LNG loss from becoming the same percentage loss of all gas.
+  globalGasDemandPerDay: 400,
   fertilizer: {
     hormuzTradeShare: 0.33,
     // Judgment: prices clear in the traded market, but domestic/non-traded

--- a/src/simulations/critical-materials/hormuz-model.ts
+++ b/src/simulations/critical-materials/hormuz-model.ts
@@ -6,7 +6,16 @@ import {
   type OilMarketParams,
   type TradedCommodityParams,
 } from './hormuz-data.js';
-import { assertFiniteDeep, validateNumber } from 'tsimulation';
+import {
+  assertFiniteDeep,
+  divideSemanticQuantities,
+  semanticQuantity,
+  validateNumber,
+} from 'tsimulation';
+import {
+  hormuzGasEquationEstimands,
+  hormuzGasLossDerivation,
+} from '../semantic-contracts.js';
 
 const clamp = (value: number, min: number, max: number): number =>
   Math.min(max, Math.max(min, value));
@@ -365,7 +374,26 @@ function regionalMonth(
   }
 
   const globalOilLoss = Math.max(0, 1 - oil.physicalSupplyRatio);
-  const globalLngLoss = Math.max(0, 1 - lng.physicalSupplyRatio);
+  const globalGasLoss = clamp(
+    divideSemanticQuantities({
+      numerator: semanticQuantity(
+        lng.netPhysicalSupplyLossPerDay,
+        'Bcf/day',
+        hormuzGasEquationEstimands.netLngSupplyLossPerDay,
+      ),
+      denominator: semanticQuantity(
+        params.globalGasDemandPerDay,
+        'Bcf/day',
+        hormuzGasEquationEstimands.globalGasDemandPerDay,
+      ),
+      outputEstimand: hormuzGasEquationEstimands.globalGasSupplyLossShare,
+      derivation: hormuzGasLossDerivation,
+      targetUnit: 'fraction',
+      label: 'global gas loss on total-gas denominator',
+    }).value,
+    0,
+    1,
+  );
   const broadGasPrice = 1 +
     (lng.priceMultiple - 1) * params.globalLngPricePassThrough;
 
@@ -379,7 +407,7 @@ function regionalMonth(
     const regionGasRouteExposure =
       exposure.lngShareOfGasUse * exposure.hormuzShareOfLng;
     const gasLoss = globalGasRouteExposure > 0
-      ? globalLngLoss *
+      ? globalGasLoss *
         (regionGasRouteExposure / globalGasRouteExposure) *
         exposure.physicalVulnerability
       : 0;
@@ -391,7 +419,7 @@ function regionalMonth(
     );
     const gasScarcityGap = Math.max(
       0,
-      (1 - gasAvailability) - globalLngLoss,
+      (1 - gasAvailability) - globalGasLoss,
     );
     const oilPriceMultiple = clamp(
       oil.priceMultiple * (1 + params.regionalScarcityPricePremium * oilScarcityGap),
@@ -435,6 +463,7 @@ export function simulateHormuzDisruption(
     ...validateNumber(scenario.startMonth, 'scenario.startMonth', { integer: true, min: 1, max: 12 }),
     ...validateNumber(params.oil.globalDemandPerDay, 'oil.globalDemandPerDay', { min: 0, exclusiveMin: true }),
     ...validateNumber(params.lng.globalDemandPerDay, 'lng.globalDemandPerDay', { min: 0, exclusiveMin: true }),
+    ...validateNumber(params.globalGasDemandPerDay, 'globalGasDemandPerDay', { min: 0, exclusiveMin: true }),
     ...validateNumber(params.oil.hormuzFlowPerDay, 'oil.hormuzFlowPerDay', { min: 0 }),
     ...validateNumber(params.lng.hormuzFlowPerDay, 'lng.hormuzFlowPerDay', { min: 0 }),
     ...validateNumber(params.oil.demandElasticity, 'oil.demandElasticity', { min: 0, exclusiveMin: true }),
@@ -449,6 +478,9 @@ export function simulateHormuzDisruption(
   }
   if (params.lng.hormuzFlowPerDay > params.lng.globalDemandPerDay) {
     errors.push('lng.hormuzFlowPerDay must not exceed global demand');
+  }
+  if (params.globalGasDemandPerDay < params.lng.globalDemandPerDay) {
+    errors.push('globalGasDemandPerDay must be at least as large as seaborne LNG demand');
   }
   if (errors.length > 0) throw new Error(`Invalid Hormuz input:\n  ${errors.join('\n  ')}`);
   let oilState: CommodityState = {

--- a/src/simulations/critical-materials/hormuz.test.ts
+++ b/src/simulations/critical-materials/hormuz.test.ts
@@ -1,8 +1,9 @@
 import { expect, printSummary, test } from '../../test-utils.js';
 import { runSimulation } from '../../simulation.js';
+import { REGIONS } from '../../domain-types.js';
 import { calibrateHormuzModel } from './hormuz-calibration.js';
 import { buildHormuzGlobalOverrides, compareHormuzGlobalImpact } from './hormuz-bridge.js';
-import { hormuzScenarios } from './hormuz-data.js';
+import { hormuzDefaults, hormuzScenarios } from './hormuz-data.js';
 import { simulateHormuzDisruption } from './hormuz-model.js';
 
 const calibrated = calibrateHormuzModel();
@@ -73,6 +74,33 @@ test('regional exposure makes India more physically constrained than Latin Ameri
     .toBeLessThan(july.regional.latam.oilAvailability);
   expect(july.regional.india.gasAvailability)
     .toBeLessThan(july.regional.russia.gasAvailability);
+});
+
+test('seaborne LNG loss is converted to the total-gas denominator', () => {
+  const params = {
+    ...hormuzDefaults,
+    regions: Object.fromEntries(REGIONS.map((region) => [
+      region,
+      { ...hormuzDefaults.regions[region], physicalVulnerability: 1 },
+    ])) as typeof hormuzDefaults.regions,
+  };
+  const result = simulateHormuzDisruption(
+    hormuzScenarios['prolonged-closure'],
+    params,
+  );
+  const month = result.months[2];
+  const weightedRegionalGasLoss = REGIONS.reduce(
+    (sum, region) =>
+      sum +
+      params.regions[region].gasConsumptionWeight *
+        (1 - month.regional[region].gasAvailability),
+    0,
+  );
+  const expectedTotalGasLoss =
+    month.lng.netPhysicalSupplyLossPerDay / params.globalGasDemandPerDay;
+  const seaborneLngLoss = 1 - month.lng.physicalSupplyRatio;
+  expect(weightedRegionalGasLoss).toBeCloseTo(expectedTotalGasLoss, 9);
+  expect(weightedRegionalGasLoss).toBeLessThan(seaborneLngLoss / 3);
 });
 
 test('the annual bridge raises burden and lowers GDP in the disruption year', () => {

--- a/src/simulations/critical-materials/shipping-network.test.ts
+++ b/src/simulations/critical-materials/shipping-network.test.ts
@@ -75,3 +75,26 @@ test('full Red Sea avoidance produces finite delay, capacity, and inflation path
     assert.ok(Number.isFinite(row.intendedMarketOilAvailability));
   }
 });
+
+test('long Cape delays remain conserved as terminal in-transit oil', () => {
+  const result = simulateMaritimeNetwork(
+    maritimeScenarios['red-sea-1h25-holdout'],
+    { capeExtraDays: 120 },
+  );
+  const dispatchedMillionBarrels = result.monthly.reduce(
+    (sum, row) =>
+      sum + row.capeOilDeparturesMbd * result.params.daysPerMonth,
+    0,
+  );
+  const arrivedMillionBarrels = result.monthly.reduce(
+    (sum, row) =>
+      sum + row.capeOilArrivalsMbd * result.params.daysPerMonth,
+    0,
+  );
+  assert.ok(result.terminalCapeOilInTransitMillionBarrels > 0);
+  assert.ok(Math.abs(
+    dispatchedMillionBarrels -
+      arrivedMillionBarrels -
+      result.terminalCapeOilInTransitMillionBarrels,
+  ) < 1e-9);
+});

--- a/src/simulations/critical-materials/shipping-network.ts
+++ b/src/simulations/critical-materials/shipping-network.ts
@@ -4,7 +4,12 @@ import {
   type MaritimeNetworkParams,
   type MaritimeScenario,
 } from './shipping-data.js';
-import { assertFiniteDeep, validateNumber } from 'tsimulation';
+import {
+  advanceTransitLedger,
+  assertFiniteDeep,
+  createTransitLedger,
+  validateNumber,
+} from 'tsimulation';
 
 export interface MaritimeMonthResult {
   year: number;
@@ -42,6 +47,7 @@ export interface MaritimeSimulationResult {
   params: MaritimeNetworkParams;
   monthly: readonly MaritimeMonthResult[];
   annual: readonly MaritimeAnnualResult[];
+  terminalCapeOilInTransitMillionBarrels: number;
 }
 
 const clamp = (value: number, min: number, max: number): number =>
@@ -120,15 +126,13 @@ export function simulateMaritimeNetwork(
     scenario.babThroughputPath.length,
     scenario.suezThroughputPath.length,
   );
-  const arrivalSchedule = Array.from({ length: months + 3 }, () => 0);
+  let capeTransit = createTransitLedger('million-barrel');
   const inflationSchedule = Array.from(
     { length: months + params.importInflationLagMonths + 1 },
     () => 0,
   );
   const monthly: MaritimeMonthResult[] = [];
   const delayMonths = params.capeExtraDays / params.daysPerMonth;
-  const delayFloor = Math.floor(delayMonths);
-  const delayRemainder = delayMonths - delayFloor;
 
   for (let index = 0; index < months; index++) {
     const { year, month } = dateAt(scenario.startYear, scenario.startMonth, index);
@@ -152,10 +156,14 @@ export function simulateMaritimeNetwork(
     const capeOilDeparturesMbd = blockedOilMbd * params.oilCapeRerouteShare;
     const reorientedOilMbd = blockedOilMbd - capeOilDeparturesMbd;
 
-    const firstArrival = index + delayFloor;
-    arrivalSchedule[firstArrival] += capeOilDeparturesMbd * (1 - delayRemainder);
-    arrivalSchedule[firstArrival + 1] += capeOilDeparturesMbd * delayRemainder;
-    const capeOilArrivalsMbd = arrivalSchedule[index];
+    const transit = advanceTransitLedger(capeTransit, {
+      step: index,
+      dispatchAmount: capeOilDeparturesMbd * params.daysPerMonth,
+      delaySteps: delayMonths,
+      batchId: `cape-oil-${year}-${month}`,
+    });
+    capeTransit = transit.state;
+    const capeOilArrivalsMbd = transit.arrived / params.daysPerMonth;
     const intendedDelivered = directOilMbd + capeOilArrivalsMbd;
     const intendedMarketOilAvailability = oilAvailableToRedSeaMbd > 0
       ? clamp(intendedDelivered / oilAvailableToRedSeaMbd, 0, 1.5)
@@ -223,7 +231,14 @@ export function simulateMaritimeNetwork(
     };
   });
 
-  const result = { scenario, params, monthly, annual };
+  const result = {
+    scenario,
+    params,
+    monthly,
+    annual,
+    terminalCapeOilInTransitMillionBarrels:
+      capeTransit.batches.reduce((sum, batch) => sum + batch.amount, 0),
+  };
   assertFiniteDeep(result, 'maritime network result');
   return result;
 }

--- a/src/simulations/e-bike-motors/measurement-contracts.ts
+++ b/src/simulations/e-bike-motors/measurement-contracts.ts
@@ -127,7 +127,11 @@ function regionStockEstimand(region: EbikeRegion): EstimandContract {
 
 function regionMarketComponentEstimand(
   region: EbikeRegion,
-  component: 'replacement' | 'new-adoption',
+  component:
+    | 'retirement'
+    | 'replacement'
+    | 'unreplaced-retirement'
+    | 'new-adoption',
 ): EstimandContract {
   return estimand(`${region}.${component}-complete-ebike-market-flow`, {
     quantityKind: `e-bike.${region}.${component}.complete-bike-market-flow`,
@@ -135,9 +139,13 @@ function regionMarketComponentEstimand(
     population: {
       ...completeEbikePopulation,
       inclusion: [
-        component === 'replacement'
-          ? 'complete bikes replacing retirements from the installed fleet'
-          : 'complete bikes that increase the installed fleet',
+        component === 'retirement'
+          ? 'complete bikes reaching scheduled end of service life'
+          : component === 'replacement'
+            ? 'complete bikes replacing retirements from the installed fleet'
+            : component === 'unreplaced-retirement'
+              ? 'scheduled retirements not replaced by a new complete bike'
+              : 'complete bikes that increase the installed fleet',
       ],
     },
     geography: geographies[region],
@@ -191,6 +199,18 @@ export const ebikeMotorEstimands = {
     EBIKE_REGIONS.map((region) => [
       region,
       regionMarketComponentEstimand(region, 'replacement'),
+    ]),
+  ) as Record<EbikeRegion, EstimandContract>,
+  regionalRetirementFlow: Object.fromEntries(
+    EBIKE_REGIONS.map((region) => [
+      region,
+      regionMarketComponentEstimand(region, 'retirement'),
+    ]),
+  ) as Record<EbikeRegion, EstimandContract>,
+  regionalUnreplacedRetirementFlow: Object.fromEntries(
+    EBIKE_REGIONS.map((region) => [
+      region,
+      regionMarketComponentEstimand(region, 'unreplaced-retirement'),
     ]),
   ) as Record<EbikeRegion, EstimandContract>,
   regionalNewAdoptionFlow: Object.fromEntries(

--- a/src/simulations/e-bike-motors/model.test.ts
+++ b/src/simulations/e-bike-motors/model.test.ts
@@ -77,6 +77,28 @@ test('regional, architecture, and supplier volumes reconcile every year', () => 
       assert.ok(row.entrantUnits <= row.entrantAddressableUnits + 1e-8);
       assert.ok(row.entrantShareOfAddressableMarket >= 0);
       assert.ok(row.entrantShareOfAddressableMarket <= 1);
+      assert.ok(
+        Math.abs(
+          row.endingInstalledStock -
+            (row.beginningInstalledStock -
+              row.retirements +
+              row.annualSales),
+        ) < 1e-6,
+      );
+      assert.ok(
+        Math.abs(
+          row.annualSales -
+            row.replacementSales -
+            row.newAdoptionSales,
+        ) < 1e-8,
+      );
+      assert.ok(
+        Math.abs(
+          row.retirements -
+            row.replacementSales -
+            row.unreplacedRetirements,
+        ) < 1e-8,
+      );
     }
     assert.ok(year.entrant.annualUnits <= year.entrant.factoryCapacity + 1e-8);
     assert.ok(
@@ -156,5 +178,30 @@ test('invalid regional identities fail before simulation', () => {
   assert.throws(
     () => simulateEbikeMotorMarket(scenario),
     /scenario\.regions\.us\.id must equal 'us'/,
+  );
+});
+
+test('a shrinking market retires vintages instead of preserving phantom stock', () => {
+  const scenario = structuredClone(ebikeMotorScenarios['full-stack']);
+  scenario.endYear = scenario.startYear + 2;
+  scenario.entrant.launchYear = scenario.startYear;
+  scenario.regions.us.annualPopulationGrowth = -0.5;
+  scenario.regions.us.saturationStockPerThousandPeople = 1;
+  scenario.regions.us.baseAnnualSales = 0;
+  const result = simulateEbikeMotorMarket(scenario);
+  const first = result.years[0].regions.us;
+  const last = result.years.at(-1)!.regions.us;
+  assert.ok(first.retirements > 0);
+  assert.equal(first.replacementSales, 0);
+  assert.equal(first.unreplacedRetirements, first.retirements);
+  assert.ok(last.endingInstalledStock < first.beginningInstalledStock);
+});
+
+test('fractional replacement lives are rejected before cohort accounting', () => {
+  const scenario = structuredClone(ebikeMotorScenarios['full-stack']);
+  scenario.regions.eu.replacementYears = 9.5;
+  assert.throws(
+    () => simulateEbikeMotorMarket(scenario),
+    /replacementYears must be an integer/,
   );
 });

--- a/src/simulations/e-bike-motors/model.ts
+++ b/src/simulations/e-bike-motors/model.ts
@@ -1,5 +1,9 @@
 import {
+  advanceVintageStock,
   assertFiniteDeep,
+  createVintageStock,
+  scheduledVintageRetirements,
+  type VintageStockState,
   validateNumber,
   validateShares,
 } from 'tsimulation';
@@ -41,7 +45,9 @@ export interface RegionalMotorYear {
   region: EbikeRegion;
   populationMillions: number;
   beginningInstalledStock: number;
+  retirements: number;
   replacementSales: number;
+  unreplacedRetirements: number;
   newAdoptionSales: number;
   annualSales: number;
   endingInstalledStock: number;
@@ -115,6 +121,7 @@ interface RegionalState {
   populationMillions: number;
   stock: number;
   midDriveShare: number;
+  vintages: VintageStockState;
 }
 
 interface EntrantCommercialState {
@@ -168,6 +175,7 @@ function validateRegionalParams(
       max: 1,
     }),
     ...validateNumber(params.replacementYears, `${path}.replacementYears`, {
+      integer: true,
       min: 1,
     }),
     ...validateNumber(params.baseMidDriveShare, `${path}.baseMidDriveShare`, {
@@ -411,21 +419,32 @@ function regionalAdoption(
       ? state.populationMillions
       : state.populationMillions * (1 + params.annualPopulationGrowth);
   const beginningStock = state.stock;
-  const replacementSales = beginningStock / params.replacementYears;
+  const step = year - params.baseYear;
+  const retirements = scheduledVintageRetirements(state.vintages, step);
+  let replacementSales: number;
   let newAdoptionSales: number;
   let annualSales: number;
 
   if (year === params.baseYear) {
     annualSales = params.baseAnnualSales;
+    replacementSales = Math.min(retirements, annualSales);
     newAdoptionSales = Math.max(0, annualSales - replacementSales);
   } else {
     const targetStock =
       populationMillions *
       1_000_000 *
       (params.saturationStockPerThousandPeople / 1_000);
-    const remainingPotential = Math.max(0, targetStock - beginningStock);
+    const stockAfterRetirement = Math.max(0, beginningStock - retirements);
+    replacementSales = Math.min(
+      retirements,
+      Math.max(0, targetStock - stockAfterRetirement),
+    );
+    const stockAfterReplacement = stockAfterRetirement + replacementSales;
+    const remainingPotential = Math.max(0, targetStock - stockAfterReplacement);
     const adoptionFraction =
-      targetStock > 0 ? clamp(beginningStock / targetStock, 0, 1) : 1;
+      targetStock > 0
+        ? clamp(stockAfterReplacement / targetStock, 0, 1)
+        : 1;
     newAdoptionSales = Math.min(
       remainingPotential,
       Math.max(
@@ -437,10 +456,14 @@ function regionalAdoption(
     annualSales = replacementSales + newAdoptionSales;
   }
 
-  const endingInstalledStock = Math.max(
-    0,
-    beginningStock + newAdoptionSales,
-  );
+  const vintageAdvance = advanceVintageStock(state.vintages, {
+    step,
+    additions: annualSales,
+    serviceLifeSteps: params.replacementYears,
+    cohortId: `${params.id}-${year}`,
+  });
+  const endingInstalledStock = vintageAdvance.closingStock;
+  const unreplacedRetirements = Math.max(0, retirements - replacementSales);
   const midDriveShare =
     year === params.baseYear
       ? params.baseMidDriveShare
@@ -449,13 +472,16 @@ function regionalAdoption(
           (params.targetMidDriveShare - state.midDriveShare);
   state.populationMillions = populationMillions;
   state.stock = endingInstalledStock;
+  state.vintages = vintageAdvance.state;
   state.midDriveShare = clamp(midDriveShare, 0, 1);
 
   return {
     region: params.id,
     populationMillions,
     beginningInstalledStock: beginningStock,
+    retirements,
     replacementSales,
+    unreplacedRetirements,
     newAdoptionSales,
     annualSales,
     endingInstalledStock,
@@ -766,6 +792,13 @@ export function simulateEbikeMotorMarket(
           populationMillions: params.populationMillions,
           stock: params.initialInstalledStock,
           midDriveShare: params.baseMidDriveShare,
+          vintages: createVintageStock({
+            unit: 'ebike',
+            initialStock: params.initialInstalledStock,
+            serviceLifeSteps: params.replacementYears,
+            initialRetirementProfile: 'uniform',
+            idPrefix: `${region}-opening`,
+          }),
         },
       ];
     }),

--- a/src/simulations/e-bike-motors/ports.ts
+++ b/src/simulations/e-bike-motors/ports.ts
@@ -162,9 +162,17 @@ function regionalMotorYearPort(region: EbikeRegion) {
       'ebike',
       ebikeMotorEstimands.regionalInstalledStock[region],
     ),
+    retirements: measurementPort(
+      'ebike/year',
+      ebikeMotorEstimands.regionalRetirementFlow[region],
+    ),
     replacementSales: measurementPort(
       'ebike/year',
       ebikeMotorEstimands.regionalReplacementFlow[region],
+    ),
+    unreplacedRetirements: measurementPort(
+      'ebike/year',
+      ebikeMotorEstimands.regionalUnreplacedRetirementFlow[region],
     ),
     newAdoptionSales: measurementPort(
       'ebike/year',

--- a/src/simulations/news/ai-capital-cycle.test.ts
+++ b/src/simulations/news/ai-capital-cycle.test.ts
@@ -52,3 +52,39 @@ test('monetization assumptions create a wide financing fork', () => {
   assert.ok(slow.endingDebtBalanceBillion > fast.endingDebtBalanceBillion);
 });
 
+test('calendar quarters, lags, and depreciation lives require quarter granularity', () => {
+  assert.throws(
+    () => simulateAiCapitalCycleV2({
+      ...aiCapitalCycleScenarios.central,
+      quarters: 1.5,
+    }),
+    /quarters must be an integer/,
+  );
+  assert.throws(
+    () => simulateAiCapitalCycleV2({
+      ...aiCapitalCycleScenarios.central,
+      startQuarter: 1.5,
+    }),
+    /startQuarter must be an integer/,
+  );
+  assert.throws(
+    () => simulateAiCapitalCycleV2({
+      ...aiCapitalCycleScenarios.central,
+      chipDeploymentLagQuarters: 1.5,
+    }),
+    /chipDeploymentLagQuarters must be an integer/,
+  );
+  assert.throws(
+    () => simulateAiCapitalCycleV2({
+      ...aiCapitalCycleScenarios.central,
+      chipUsefulLifeYears: 4.1,
+    }),
+    /integer number of quarters/,
+  );
+});
+
+test('new capex vintages expose a finite terminal book stock', () => {
+  const result = simulateAiCapitalCycleV2(aiCapitalCycleScenarios.central);
+  assert.ok(result.endingNewCapexBookValueBillion > 0);
+  assert.ok(Number.isFinite(result.endingNewCapexBookValueBillion));
+});

--- a/src/simulations/news/ai-capital-cycle.ts
+++ b/src/simulations/news/ai-capital-cycle.ts
@@ -1,4 +1,10 @@
-import { assertFiniteDeep, validateNumber } from 'tsimulation';
+import {
+  assertFiniteDeep,
+  depreciableVintage,
+  straightLineDepreciation,
+  type DepreciableVintage,
+  validateNumber,
+} from 'tsimulation';
 
 export interface AiCapitalCycleScenario {
   id: string;
@@ -63,18 +69,19 @@ export interface AiCapitalCycleResult {
   endingCumulativeNetCashBillion: number;
   endingDebtBalanceBillion: number;
   endingCapexReplacementCoverage: number;
-}
-
-interface CapexCohort {
-  quarter: number;
-  capexBillion: number;
+  endingNewCapexBookValueBillion: number;
 }
 
 function validateScenario(scenario: AiCapitalCycleScenario): void {
   assertFiniteDeep(scenario, 'AI capital-cycle scenario');
   const errors = [
-    ...validateNumber(scenario.startQuarter, 'startQuarter', { min: 1, max: 4 }),
-    ...validateNumber(scenario.quarters, 'quarters', { min: 1 }),
+    ...validateNumber(scenario.startYear, 'startYear', { integer: true }),
+    ...validateNumber(scenario.startQuarter, 'startQuarter', {
+      integer: true,
+      min: 1,
+      max: 4,
+    }),
+    ...validateNumber(scenario.quarters, 'quarters', { integer: true, min: 1 }),
     ...validateNumber(
       scenario.startingQuarterlyAiRevenueBillion,
       'startingQuarterlyAiRevenueBillion',
@@ -105,6 +112,16 @@ function validateScenario(scenario: AiCapitalCycleScenario): void {
       min: 0,
       exclusiveMin: true,
     }),
+    ...validateNumber(
+      scenario.chipDeploymentLagQuarters,
+      'chipDeploymentLagQuarters',
+      { integer: true, min: 0 },
+    ),
+    ...validateNumber(
+      scenario.facilityDeploymentLagQuarters,
+      'facilityDeploymentLagQuarters',
+      { integer: true, min: 0 },
+    ),
     ...validateNumber(scenario.replacementCostPremium, 'replacementCostPremium', {
       min: 0,
       exclusiveMin: true,
@@ -121,6 +138,12 @@ function validateScenario(scenario: AiCapitalCycleScenario): void {
   }
   if (scenario.annualTotalDeveloperCapexBillion.length === 0) {
     errors.push('annualTotalDeveloperCapexBillion must not be empty');
+  }
+  if (!Number.isInteger(scenario.chipUsefulLifeYears * 4)) {
+    errors.push('chipUsefulLifeYears must resolve to an integer number of quarters');
+  }
+  if (!Number.isInteger(scenario.facilityUsefulLifeYears * 4)) {
+    errors.push('facilityUsefulLifeYears must resolve to an integer number of quarters');
   }
   scenario.annualRevenueGrowthPath.forEach((value, index) => {
     errors.push(
@@ -194,12 +217,9 @@ export function simulateAiCapitalCycleV2(
   validateScenario(scenario);
 
   const initialSnapshot = simulateAiCapitalCycleV1(scenario);
-  const capexCohorts: CapexCohort[] = [];
+  const capexVintages: DepreciableVintage[] = [];
   const chipLifeQuarters = scenario.chipUsefulLifeYears * 4;
   const facilityLifeQuarters = scenario.facilityUsefulLifeYears * 4;
-  const weightedLegacyLifeQuarters =
-    scenario.chipShareOfAiCapex * chipLifeQuarters +
-    (1 - scenario.chipShareOfAiCapex) * facilityLifeQuarters;
 
   let revenueBillion = scenario.startingQuarterlyAiRevenueBillion;
   let cumulativeNetCashBillion = 0;
@@ -228,35 +248,34 @@ export function simulateAiCapitalCycleV2(
       totalDeveloperCapexBillion *
       scenario.aiShareOfDeveloperCapex /
       4;
-    capexCohorts.push({ quarter: index, capexBillion: aiCapexBillion });
+    capexVintages.push(
+      depreciableVintage({
+        id: `chips-${index}`,
+        expenditureStep: index,
+        inServiceStep: index + scenario.chipDeploymentLagQuarters,
+        cost: aiCapexBillion * scenario.chipShareOfAiCapex,
+        usefulLifeSteps: chipLifeQuarters,
+      }),
+      depreciableVintage({
+        id: `facilities-${index}`,
+        expenditureStep: index,
+        inServiceStep: index + scenario.facilityDeploymentLagQuarters,
+        cost: aiCapexBillion * (1 - scenario.chipShareOfAiCapex),
+        usefulLifeSteps: facilityLifeQuarters,
+      }),
+    );
 
-    // The starting depreciation stock is treated as a uniformly aged pool,
-    // so it expires gradually rather than remaining forever.
+    // The starting depreciation stock is split into separate uniformly aged
+    // chip and facility pools rather than compressed into one average life.
     const legacyDepreciationBillion =
-      scenario.startingQuarterlyAiDepreciationBillion *
-      Math.max(0, 1 - index / weightedLegacyLifeQuarters);
-    let newDepreciationBillion = 0;
-    for (const cohort of capexCohorts) {
-      const age = index - cohort.quarter;
-      if (
-        age >= scenario.chipDeploymentLagQuarters &&
-        age < scenario.chipDeploymentLagQuarters + chipLifeQuarters
-      ) {
-        newDepreciationBillion +=
-          cohort.capexBillion *
-          scenario.chipShareOfAiCapex /
-          chipLifeQuarters;
-      }
-      if (
-        age >= scenario.facilityDeploymentLagQuarters &&
-        age < scenario.facilityDeploymentLagQuarters + facilityLifeQuarters
-      ) {
-        newDepreciationBillion +=
-          cohort.capexBillion *
-          (1 - scenario.chipShareOfAiCapex) /
-          facilityLifeQuarters;
-      }
-    }
+      scenario.startingQuarterlyAiDepreciationBillion * (
+        scenario.chipShareOfAiCapex *
+          Math.max(0, 1 - index / chipLifeQuarters) +
+        (1 - scenario.chipShareOfAiCapex) *
+          Math.max(0, 1 - index / facilityLifeQuarters)
+      );
+    const newDepreciationBillion =
+      straightLineDepreciation(capexVintages, index).depreciation;
     const depreciationBillion =
       legacyDepreciationBillion + newDepreciationBillion;
     const cashOperatingCostBillion =
@@ -348,6 +367,11 @@ export function simulateAiCapitalCycleV2(
         ? (quarters.at(-1)?.aiCapexBillion ?? 0) /
           (quarters.at(-1)?.maintenanceCapexBillion ?? 1)
         : 1,
+    endingNewCapexBookValueBillion:
+      straightLineDepreciation(
+        capexVintages,
+        Math.max(0, scenario.quarters - 1),
+      ).endingBookValue,
   };
   assertFiniteDeep(result, 'AI capital-cycle V2 result');
   return result;

--- a/src/simulations/news/data-center-grid.test.ts
+++ b/src/simulations/news/data-center-grid.test.ts
@@ -70,6 +70,44 @@ test('clean dedicated supply changes emissions, not cost-allocation arithmetic',
   assert.ok(clean.operationalEmissionsGtCo2 < gas.operationalEmissionsGtCo2 / 5);
 });
 
+test('annual energy share does not masquerade as nameplate capacity share', () => {
+  const base = dataCenterGridScenarios['full-pledge-gas'];
+  const highCapacityFactor = simulateDataCenterGrid({
+    ...base,
+    dedicatedPortfolioCapacityFactor: 0.90,
+  });
+  const lowCapacityFactor = simulateDataCenterGrid({
+    ...base,
+    dedicatedPortfolioCapacityFactor: 0.45,
+  });
+  assert.equal(
+    highCapacityFactor.dedicatedElectricityTwh,
+    lowCapacityFactor.dedicatedElectricityTwh,
+  );
+  assert.ok(
+    Math.abs(
+      lowCapacityFactor.dedicatedNameplateGw /
+        highCapacityFactor.dedicatedNameplateGw -
+        2,
+    ) < 1e-12,
+  );
+  assert.ok(
+    lowCapacityFactor.dedicatedGenerationCapexBillion >
+      highCapacityFactor.dedicatedGenerationCapexBillion,
+  );
+});
+
+test('dedicated capacity factor must be positive before nameplate division', () => {
+  const scenario = structuredClone(
+    dataCenterGridScenarios['full-pledge-clean-flex'],
+  );
+  scenario.dedicatedPortfolioCapacityFactor = 0;
+  assert.throws(
+    () => simulateDataCenterGrid(scenario),
+    /dedicatedPortfolioCapacityFactor must be > 0/,
+  );
+});
+
 test('take-or-pay prevents abandoned contracted load from shifting assigned capex', () => {
   const base = {
     ...dataCenterGridScenarios['full-pledge-clean-flex'],
@@ -90,6 +128,21 @@ test('take-or-pay prevents abandoned contracted load from shifting assigned cape
   assert.ok(
     unprotectedResult.nonDataCenterBillImpact >
       protectedResult.nonDataCenterBillImpact,
+  );
+});
+
+test('dedicated build follows the contract while dispatch follows realized load', () => {
+  const base = dataCenterGridScenarios['full-pledge-clean-flex'];
+  const full = simulateDataCenterGrid(base);
+  const halfRealized = simulateDataCenterGrid({
+    ...base,
+    id: 'half-realized',
+    expectedLoadRealization: 0.5,
+  });
+  assert.equal(halfRealized.dedicatedNameplateGw, full.dedicatedNameplateGw);
+  assert.equal(
+    halfRealized.dedicatedElectricityTwh,
+    full.dedicatedElectricityTwh / 2,
   );
 });
 

--- a/src/simulations/news/data-center-grid.ts
+++ b/src/simulations/news/data-center-grid.ts
@@ -1,4 +1,14 @@
-import { assertFiniteDeep, validateNumber } from 'tsimulation';
+import {
+  assertFiniteDeep,
+  divideSemanticQuantities,
+  multiplySemanticQuantities,
+  semanticQuantity,
+  validateNumber,
+} from 'tsimulation';
+import {
+  dataCenterEquationDerivations,
+  dataCenterEstimands,
+} from '../semantic-contracts.js';
 
 const clamp = (value: number, min: number, max: number): number =>
   Math.min(max, Math.max(min, value));
@@ -14,8 +24,14 @@ export interface DataCenterGridScenario {
   peakCoincidenceFactor: number;
   /** Share of coincident load that can be curtailed during scarcity. */
   flexibleLoadShare: number;
-  /** Share of annual data-center energy backed by additive dedicated supply. */
+  /**
+   * Share of the contracted annual energy requirement provisioned with
+   * additive dedicated supply. The same portfolio serves that share of
+   * realized energy; unused capacity is stranded if load does not materialize.
+   */
   dedicatedGenerationShare: number;
+  /** Annual output divided by dedicated nameplate capacity times annual hours. */
+  dedicatedPortfolioCapacityFactor: number;
   /** Firm-capacity credit of the dedicated supply portfolio. */
   dedicatedCapacityCredit: number;
   /** Shared firm capacity actually completed for the incremental load. */
@@ -47,6 +63,7 @@ export interface DataCenterGridResult {
   annualElectricityTwh: number;
   coincidentPeakGw: number;
   flexiblePeakGw: number;
+  dedicatedNameplateGw: number;
   dedicatedFirmCapacityGw: number;
   sharedFirmCapacityRequiredGw: number;
   sharedFirmCapacityBuiltGw: number;
@@ -83,6 +100,11 @@ function validateScenario(scenario: DataCenterGridScenario): void {
       min: 0,
     }),
     ...validateNumber(scenario.sharedFirmBuildGw, 'sharedFirmBuildGw', { min: 0 }),
+    ...validateNumber(
+      scenario.dedicatedPortfolioCapacityFactor,
+      'dedicatedPortfolioCapacityFactor',
+      { min: 0, exclusiveMin: true, max: 1 },
+    ),
     ...validateNumber(scenario.generationCapexPerKw, 'generationCapexPerKw', { min: 0 }),
     ...validateNumber(scenario.networkCapexPerKw, 'networkCapexPerKw', { min: 0 }),
     ...validateNumber(scenario.fixedChargeRate, 'fixedChargeRate', { min: 0, max: 1 }),
@@ -121,16 +143,93 @@ export function simulateDataCenterGrid(
 ): DataCenterGridResult {
   validateScenario(scenario);
 
+  const realizedAverageLoad = multiplySemanticQuantities({
+    quantities: [
+      semanticQuantity(
+        scenario.incrementalContractedLoadGw,
+        'GW',
+        dataCenterEstimands.incrementalContractedLoadGw,
+      ),
+      semanticQuantity(
+        scenario.expectedLoadRealization,
+        'fraction',
+        dataCenterEstimands.expectedLoadRealization,
+      ),
+      semanticQuantity(
+        scenario.loadFactor,
+        'fraction',
+        dataCenterEstimands.loadFactor,
+      ),
+    ],
+    outputEstimand: dataCenterEstimands.realizedAverageLoadGw,
+    derivation: dataCenterEquationDerivations.realizedAverageLoad,
+    targetUnit: 'GW',
+    label: 'realized average data-center load',
+  });
+  const realizedAverageLoadGw = realizedAverageLoad.value;
   const realizedContractedLoadGw =
     scenario.incrementalContractedLoadGw * scenario.expectedLoadRealization;
-  const realizedAverageLoadGw = realizedContractedLoadGw * scenario.loadFactor;
-  const annualElectricityTwh =
-    realizedAverageLoadGw * scenario.hoursPerYear / 1_000;
+  const annualElectricityTwh = multiplySemanticQuantities({
+    quantities: [
+      realizedAverageLoad,
+      semanticQuantity(
+        scenario.hoursPerYear,
+        'hour/year',
+        dataCenterEstimands.hoursPerYear,
+      ),
+    ],
+    outputEstimand: dataCenterEstimands.annualElectricityTwh,
+    derivation: dataCenterEquationDerivations.annualElectricity,
+    targetUnit: 'TWh/year',
+    label: 'annual data-center electricity',
+  }).value;
   const coincidentPeakGw =
     realizedContractedLoadGw * scenario.peakCoincidenceFactor;
   const flexiblePeakGw = coincidentPeakGw * scenario.flexibleLoadShare;
-  const dedicatedNameplateGw =
-    scenario.incrementalContractedLoadGw * scenario.dedicatedGenerationShare;
+  const contractedAverageLoad = multiplySemanticQuantities({
+    quantities: [
+      semanticQuantity(
+        scenario.incrementalContractedLoadGw,
+        'GW',
+        dataCenterEstimands.incrementalContractedLoadGw,
+      ),
+      semanticQuantity(
+        scenario.loadFactor,
+        'fraction',
+        dataCenterEstimands.loadFactor,
+      ),
+    ],
+    outputEstimand: dataCenterEstimands.contractedAverageLoadGw,
+    derivation: dataCenterEquationDerivations.contractedAverageLoad,
+    targetUnit: 'GW',
+    label: 'contracted average data-center load',
+  });
+  const dedicatedAverageLoad = multiplySemanticQuantities({
+    quantities: [
+      contractedAverageLoad,
+      semanticQuantity(
+        scenario.dedicatedGenerationShare,
+        'fraction',
+        dataCenterEstimands.dedicatedGenerationShare,
+      ),
+    ],
+    outputEstimand: dataCenterEstimands.dedicatedAverageLoadGw,
+    derivation: dataCenterEquationDerivations.dedicatedAverageLoad,
+    targetUnit: 'GW',
+    label: 'dedicated average generation requirement',
+  });
+  const dedicatedNameplateGw = divideSemanticQuantities({
+    numerator: dedicatedAverageLoad,
+    denominator: semanticQuantity(
+      scenario.dedicatedPortfolioCapacityFactor,
+      'fraction',
+      dataCenterEstimands.dedicatedPortfolioCapacityFactor,
+    ),
+    outputEstimand: dataCenterEstimands.dedicatedNameplateGw,
+    derivation: dataCenterEquationDerivations.dedicatedNameplate,
+    targetUnit: 'GW',
+    label: 'dedicated generation nameplate capacity',
+  }).value;
   const dedicatedFirmCapacityGw =
     dedicatedNameplateGw * scenario.dedicatedCapacityCredit;
   const sharedFirmCapacityRequiredGw = Math.max(
@@ -202,6 +301,7 @@ export function simulateDataCenterGrid(
     annualElectricityTwh,
     coincidentPeakGw,
     flexiblePeakGw,
+    dedicatedNameplateGw,
     dedicatedFirmCapacityGw,
     sharedFirmCapacityRequiredGw,
     sharedFirmCapacityBuiltGw,
@@ -234,6 +334,7 @@ const common2035: Omit<
   | 'takeOrPayCoverage'
   | 'dedicatedEmissionsKgPerMwh'
   | 'sharedFirmBuildGw'
+  | 'dedicatedPortfolioCapacityFactor'
 > = {
   // BloombergNEF's headline 194 GW in 2035 less its earlier 35 GW operating
   // base. A 60% fleet-wide utilization factor approximately reconciles that
@@ -263,6 +364,7 @@ export const dataCenterGridScenarios: Readonly<Record<string, DataCenterGridScen
     label: 'Shared grid build with socialized capital cost',
     flexibleLoadShare: 0.05,
     dedicatedGenerationShare: 0,
+    dedicatedPortfolioCapacityFactor: 0.60,
     sharedFirmBuildGw: 120,
     generationCostResponsibility: 0,
     networkCostResponsibility: 0,
@@ -275,6 +377,7 @@ export const dataCenterGridScenarios: Readonly<Record<string, DataCenterGridScen
     label: 'Dedicated generation, but network costs remain shared',
     flexibleLoadShare: 0.05,
     dedicatedGenerationShare: 1,
+    dedicatedPortfolioCapacityFactor: 0.85,
     sharedFirmBuildGw: 10,
     generationCostResponsibility: 1,
     networkCostResponsibility: 0,
@@ -287,6 +390,7 @@ export const dataCenterGridScenarios: Readonly<Record<string, DataCenterGridScen
     label: 'Full cost responsibility with gas-heavy dedicated power',
     flexibleLoadShare: 0.05,
     dedicatedGenerationShare: 1,
+    dedicatedPortfolioCapacityFactor: 0.85,
     sharedFirmBuildGw: 10,
     generationCostResponsibility: 1,
     networkCostResponsibility: 1,
@@ -299,6 +403,7 @@ export const dataCenterGridScenarios: Readonly<Record<string, DataCenterGridScen
     label: 'Full cost responsibility, clean supply, and flexible compute',
     flexibleLoadShare: 0.25,
     dedicatedGenerationShare: 1,
+    dedicatedPortfolioCapacityFactor: 0.55,
     sharedFirmBuildGw: 0,
     generationCostResponsibility: 1,
     networkCostResponsibility: 1,

--- a/src/simulations/registry-port-schemas.ts
+++ b/src/simulations/registry-port-schemas.ts
@@ -304,6 +304,10 @@ export const DATA_CENTER_GRID_SCENARIO_PORT = objectPort<DataCenterGridScenario>
     'fraction',
     dataCenterEstimands.dedicatedGenerationShare,
   ),
+  dedicatedPortfolioCapacityFactor: measurementPort(
+    'fraction',
+    dataCenterEstimands.dedicatedPortfolioCapacityFactor,
+  ),
   dedicatedCapacityCredit: measurementPort(
     'fraction',
     dataCenterEstimands.dedicatedCapacityCredit,
@@ -379,6 +383,10 @@ export const DATA_CENTER_GRID_RESULT_PORT = objectPort<DataCenterGridResult>({
   flexiblePeakGw: measurementPort(
     'GW',
     dataCenterEstimands.flexiblePeakGw,
+  ),
+  dedicatedNameplateGw: measurementPort(
+    'GW',
+    dataCenterEstimands.dedicatedNameplateGw,
   ),
   dedicatedFirmCapacityGw: measurementPort(
     'GW',
@@ -963,6 +971,7 @@ export const HORMUZ_REGION_EXPOSURE_PORT = objectPort<HormuzRegionExposure>({
 export const HORMUZ_PARAMS_PORT = objectPort<HormuzModelParams>({
   oil: OIL_PARAMS_PORT,
   lng: LNG_PARAMS_PORT,
+  globalGasDemandPerDay: unitPort('Bcf/day'),
   fertilizer: FERTILIZER_PARAMS_PORT,
   regions: recordPort<HormuzRegionExposure>(HORMUZ_REGION_EXPOSURE_PORT, { keys: REGIONS }),
   globalLngPricePassThrough: unitPort('fraction'),

--- a/src/simulations/registry.test.ts
+++ b/src/simulations/registry.test.ts
@@ -64,7 +64,7 @@ function discoverSimulationEntrypoints(directory: string): string[] {
 }
 
 test('standalone model registry has recursive dimensional coverage', () => {
-  const audit = auditModelContracts(SIMULATION_MODELS);
+  const audit = auditModelContracts(SIMULATION_MODELS, 'required');
   assert.equal(audit.valid, true, audit.errors.join('\n'));
   assert.ok(audit.unitBearingContracts > 300);
   assert.ok(audit.structuredContracts > 50);
@@ -75,9 +75,16 @@ test('standalone model registry has recursive dimensional coverage', () => {
     'model war-ai-factorial.output.paths',
   ]);
   assert.equal(audit.opaqueContracts, 3);
+  assert.deepEqual(audit.missingSemanticPaths, []);
+  assert.deepEqual(audit.incompleteSemanticPaths, []);
+  assert.equal(
+    audit.semanticContracts,
+    audit.unitBearingContracts,
+    'every quantitative boundary must carry complete semantics',
+  );
 });
 
-test('migrated forecasting boundaries have complete semantic contracts', () => {
+test('forecasting boundaries preserve authored measurements under mandatory semantics', () => {
   const audit = auditModelContracts(
     [dataCenterGridModel, outbreakForecastModel],
     'required',

--- a/src/simulations/registry.ts
+++ b/src/simulations/registry.ts
@@ -1,15 +1,20 @@
 import {
   ModelRegistry,
-  defineModel,
+  completeModelSemanticContracts,
+  defineModel as defineFrameworkModel,
   measurementPort,
   metadataPort,
   observationPort,
   opaquePort,
   unitPort,
   type EvidenceRecord,
+  type ModelDefinition,
   type ValidationClaim,
 } from 'tsimulation';
-import { outbreakForecastEstimands } from './semantic-contracts.js';
+import {
+  dataCenterEquationDerivations,
+  outbreakForecastEstimands,
+} from './semantic-contracts.js';
 import {
   AI_CAPITAL_CYCLE_SCENARIO_PORT,
   AI_CAPITAL_QUARTERS_PORT,
@@ -225,6 +230,12 @@ import {
   usDtc2024Measurement,
 } from './e-bike-motors/measurement-contracts.js';
 
+function defineModel<TInput, TOutput>(
+  definition: ModelDefinition<TInput, TOutput>,
+): ModelDefinition<TInput, TOutput> {
+  return defineFrameworkModel(completeModelSemanticContracts(definition));
+}
+
 const observed = (
   id: string,
   label: string,
@@ -428,6 +439,7 @@ export const dataCenterGridModel = defineModel<
   run: (scenario) => simulateDataCenterGrid(scenario),
   inputPorts: DATA_CENTER_GRID_SCENARIO_PORT.fields,
   outputPorts: DATA_CENTER_GRID_RESULT_PORT.fields,
+  semanticDerivations: Object.values(dataCenterEquationDerivations),
   invariants: [
     {
       id: 'capex-reconciliation',
@@ -713,6 +725,7 @@ export const aiCapitalCycleModel = defineModel<
     endingCumulativeNetCashBillion: unitPort('$B'),
     endingDebtBalanceBillion: unitPort('$B'),
     endingCapexReplacementCoverage: unitPort('1'),
+    endingNewCapexBookValueBillion: unitPort('$B'),
   },
   invariants: [
     {
@@ -1169,6 +1182,7 @@ export const maritimeNetworkModel = defineModel<MaritimeModelInput, MaritimeSimu
     params: MARITIME_PARAMS_PORT,
     monthly: MARITIME_MONTHS_PORT,
     annual: MARITIME_ANNUAL_ROWS_PORT,
+    terminalCapeOilInTransitMillionBarrels: unitPort('million-barrel'),
   },
   invariants: [{
     id: 'availability-range',

--- a/src/simulations/semantic-contracts.ts
+++ b/src/simulations/semantic-contracts.ts
@@ -8,6 +8,7 @@
 import {
   defineEstimand,
   defineSemanticCrosswalk,
+  defineSemanticDerivation,
   type EstimandContract,
   type SemanticCrosswalk,
 } from 'tsimulation';
@@ -18,11 +19,55 @@ type EstimandSpec = Omit<
 >;
 
 function estimand(id: string, spec: EstimandSpec): EstimandContract {
+  const measure = {
+    ...spec.measure,
+    totality: spec.measure.totality ?? 'total',
+  };
+  const population = spec.population
+    ? {
+        ...spec.population,
+        universe:
+          spec.population.universe ??
+          `Population represented by ${id} within its stated model boundary.`,
+      }
+    : {
+        id: `population.${id.replace(/^estimand\./, '')}`,
+        universe: `Population represented by ${id} within its stated model boundary.`,
+      };
+  const geography = spec.geography
+    ? {
+        ...spec.geography,
+        boundaryVersion:
+          spec.geography.boundaryVersion ?? 'declared-model-boundary-v1',
+      }
+    : {
+        id: 'geo.model-scenario-boundary',
+        boundaryVersion: 'declared-model-boundary-v1',
+      };
+  const ratio =
+    spec.ratio ??
+    (measure.kind === 'rate' ||
+    measure.kind === 'share' ||
+    measure.kind === 'index'
+      ? {
+          numerator: `${spec.quantityKind} modeled numerator`,
+          denominator: `${spec.quantityKind} applicable denominator`,
+        }
+      : undefined);
   return defineEstimand({
     schemaVersion: 'tsimulation.estimand/v1',
     id,
     version: '1.0.0',
     ...spec,
+    measure,
+    population,
+    geography,
+    ...(ratio ? { ratio } : {}),
+    time: spec.time ?? { kind: 'timeless' },
+    vintage: spec.vintage ?? {
+      basis: 'current-period',
+      convention: 'Value applies to the model period represented at the call site.',
+    },
   });
 }
 
@@ -184,10 +229,22 @@ export const dataCenterEstimands = {
     { kind: 'share' },
     {
       ratio: {
-        numerator: 'annual-data-center-electricity-from-additive-dedicated-generation',
-        denominator: 'annual-total-data-center-electricity',
+        numerator: 'contracted-annual-data-center-electricity-provisioned-by-additive-dedicated-generation',
+        denominator: 'contracted-annual-total-data-center-electricity-requirement',
       },
       time: calendarYearSum,
+    },
+  ),
+  dedicatedPortfolioCapacityFactor: dataCenterContract(
+    'dedicated-portfolio-capacity-factor',
+    'electricity.dedicated-generation-capacity-factor',
+    { kind: 'share' },
+    {
+      ratio: {
+        numerator: 'annual-dedicated-generation-output',
+        denominator: 'dedicated-nameplate-capacity-times-hours-in-period',
+      },
+      time: calendarYearMean,
     },
   ),
   dedicatedCapacityCredit: dataCenterContract(
@@ -347,6 +404,24 @@ export const dataCenterEstimands = {
     { kind: 'level', totality: 'incremental', accounting: 'gross' },
     { time: calendarYearMean },
   ),
+  contractedAverageLoadGw: dataCenterContract(
+    'contracted-average-load',
+    'electricity.annual-average-contracted-full-site-load',
+    { kind: 'level', totality: 'incremental', accounting: 'gross' },
+    { time: calendarYearMean },
+  ),
+  dedicatedAverageLoadGw: dataCenterContract(
+    'dedicated-average-load',
+    'electricity.contracted-annual-average-load-backed-by-dedicated-generation',
+    { kind: 'level', totality: 'incremental', accounting: 'gross' },
+    { time: calendarYearMean },
+  ),
+  dedicatedNameplateGw: dataCenterContract(
+    'dedicated-nameplate-capacity',
+    'electricity.dedicated-generation-nameplate-capacity',
+    { kind: 'stock', totality: 'incremental', accounting: 'gross' },
+    { time: pointInTime },
+  ),
   annualElectricityTwh: dataCenterContract(
     'annual-electricity',
     'electricity.full-site-consumption',
@@ -480,6 +555,76 @@ export const dataCenterEstimands = {
     { kind: 'flow', totality: 'incremental', accounting: 'gross' },
     { time: calendarYearSum },
   ),
+} as const;
+
+export const dataCenterEquationDerivations = {
+  realizedAverageLoad: defineSemanticDerivation({
+    schemaVersion: 'tsimulation.derivation/v1',
+    id: 'derivation.data-center.realized-average-load',
+    version: '1.0.0',
+    description:
+      'Convert contracted maximum load to realized annual-average load using realization and load factors.',
+    inputEstimandIds: [
+      dataCenterEstimands.incrementalContractedLoadGw.id,
+      dataCenterEstimands.expectedLoadRealization.id,
+      dataCenterEstimands.loadFactor.id,
+    ],
+    outputEstimand: dataCenterEstimands.realizedAverageLoadGw,
+    expression:
+      'realizedAverageLoad = incrementalContractedLoad * expectedLoadRealization * loadFactor',
+  }),
+  annualElectricity: defineSemanticDerivation({
+    schemaVersion: 'tsimulation.derivation/v1',
+    id: 'derivation.data-center.annual-electricity',
+    version: '1.0.0',
+    description: 'Integrate realized average power over annual hours.',
+    inputEstimandIds: [
+      dataCenterEstimands.realizedAverageLoadGw.id,
+      dataCenterEstimands.hoursPerYear.id,
+    ],
+    outputEstimand: dataCenterEstimands.annualElectricityTwh,
+    expression: 'annualElectricity = realizedAverageLoad * hoursPerYear',
+  }),
+  contractedAverageLoad: defineSemanticDerivation({
+    schemaVersion: 'tsimulation.derivation/v1',
+    id: 'derivation.data-center.contracted-average-load',
+    version: '1.0.0',
+    description: 'Convert maximum contracted load to its annual-average equivalent.',
+    inputEstimandIds: [
+      dataCenterEstimands.incrementalContractedLoadGw.id,
+      dataCenterEstimands.loadFactor.id,
+    ],
+    outputEstimand: dataCenterEstimands.contractedAverageLoadGw,
+    expression: 'contractedAverageLoad = incrementalContractedLoad * loadFactor',
+  }),
+  dedicatedAverageLoad: defineSemanticDerivation({
+    schemaVersion: 'tsimulation.derivation/v1',
+    id: 'derivation.data-center.dedicated-average-load',
+    version: '1.0.0',
+    description:
+      'Apply the dedicated annual-energy share to contracted average load.',
+    inputEstimandIds: [
+      dataCenterEstimands.contractedAverageLoadGw.id,
+      dataCenterEstimands.dedicatedGenerationShare.id,
+    ],
+    outputEstimand: dataCenterEstimands.dedicatedAverageLoadGw,
+    expression:
+      'dedicatedAverageLoad = contractedAverageLoad * dedicatedGenerationShare',
+  }),
+  dedicatedNameplate: defineSemanticDerivation({
+    schemaVersion: 'tsimulation.derivation/v1',
+    id: 'derivation.data-center.dedicated-nameplate-capacity',
+    version: '1.0.0',
+    description:
+      'Convert required dedicated average output to nameplate capacity using the portfolio capacity factor.',
+    inputEstimandIds: [
+      dataCenterEstimands.dedicatedAverageLoadGw.id,
+      dataCenterEstimands.dedicatedPortfolioCapacityFactor.id,
+    ],
+    outputEstimand: dataCenterEstimands.dedicatedNameplateGw,
+    expression:
+      'dedicatedNameplate = dedicatedAverageLoad / dedicatedPortfolioCapacityFactor',
+  }),
 } as const;
 
 const usResidents = {
@@ -671,6 +816,57 @@ export const hormuzEstimands = {
     },
   ),
 } as const;
+
+export const hormuzGasEquationEstimands = {
+  netLngSupplyLossPerDay: estimand(
+    'estimand.hormuz.global-net-lng-supply-loss',
+    {
+      quantityKind: 'energy.gas.net-lng-supply-loss',
+      measure: { kind: 'flow', totality: 'incremental', accounting: 'net' },
+      population: globalCommodityMarket,
+      geography: world,
+      time: simulationMonthMean,
+    },
+  ),
+  globalGasDemandPerDay: estimand(
+    'estimand.hormuz.global-total-gas-demand',
+    {
+      quantityKind: 'energy.gas.total-demand',
+      measure: { kind: 'flow', totality: 'total', accounting: 'gross' },
+      population: globalCommodityMarket,
+      geography: world,
+      time: simulationMonthMean,
+    },
+  ),
+  globalGasSupplyLossShare: estimand(
+    'estimand.hormuz.global-gas-supply-loss-share',
+    {
+      quantityKind: 'energy.gas.physical-supply-loss-share',
+      measure: { kind: 'share', totality: 'incremental', accounting: 'net' },
+      population: globalCommodityMarket,
+      geography: world,
+      ratio: {
+        numerator: 'net-global-lng-supply-loss',
+        denominator: 'total-global-gas-demand',
+      },
+      time: simulationMonthMean,
+    },
+  ),
+} as const;
+
+export const hormuzGasLossDerivation = defineSemanticDerivation({
+  schemaVersion: 'tsimulation.derivation/v1',
+  id: 'derivation.hormuz.lng-loss-to-total-gas-loss',
+  version: '1.0.0',
+  description:
+    'Place the net LNG supply loss on the denominator of total global gas demand.',
+  inputEstimandIds: [
+    hormuzGasEquationEstimands.netLngSupplyLossPerDay.id,
+    hormuzGasEquationEstimands.globalGasDemandPerDay.id,
+  ],
+  outputEstimand: hormuzGasEquationEstimands.globalGasSupplyLossShare,
+  expression: 'globalGasLoss = netLngSupplyLossPerDay / globalGasDemandPerDay',
+});
 
 export const weberEnergyInflationEstimands = {
   importEnergyPriceMultiple: estimand(


### PR DESCRIPTION
## Summary

- add first-class vintage stock, depreciation, and transit ledgers plus estimand-aware equations
- require complete model semantics by default and add verified manifest integrity hashes
- migrate energy, e-bike, AI-capital, shipping, data-center, and Hormuz accounting to the stricter primitives
- add regression coverage for lifecycle conservation, denominator correctness, and strict semantic boundaries

## Validation

- npm test
- npm run regression
- git diff --check