### PR TITLE
feat: model backstop, blocked-DC, and solar-coal headlines (2026-07-27)

### DIFF
--- a/docs/NEWS_STRESS_TESTS_2026-07-27.md
+++ b/docs/NEWS_STRESS_TESTS_2026-07-27.md
@@ -54,10 +54,10 @@ V2 prices the guarantee instead of describing it:
 
 - **Serviceability.** At 8% over 15 years the full-build lease is ~$58B/yr,
   requiring ~$195B of OpenAI revenue if this one campus can absorb 30% of a
-  compute budget. Reusing the AI capital-cycle model's monetization paths:
-  fast covers the lease by 2031, central by 2032 (about when full build
-  arrives), slow never does by 2036. The guarantee is a bet that the slow
-  path does not happen.
+  compute budget. Reusing the AI capital-cycle model's monetization paths
+  (end-of-year run rates on its 2026 axis): fast covers the lease by 2030,
+  central by 2031 (about when full build would arrive), slow never does by
+  2035. The guarantee is a bet that the slow path does not happen.
 - **Expected loss.** Weighting the three paths (25/50/25) with per-path call
   probabilities (2%/15%/60%), 60% drawn at distress, and wrong-way recovery
   (20% in the slow world, where GPU resale collapses exactly when the call

--- a/docs/NEWS_STRESS_TESTS_2026-07-27.md
+++ b/docs/NEWS_STRESS_TESTS_2026-07-27.md
@@ -1,0 +1,202 @@
+# News-driven stress tests — 27 July 2026
+
+This pass selects three stories from the 27 July news cycle that have a
+measurable target and a mechanism the simulation collection can represent:
+
+1. Nvidia is reportedly in talks to guarantee ~$250B of financing so OpenAI
+   can lease SB Energy's planned 10 GW Piketon, Ohio campus. Is this "Lucent
+   redux" vendor financing?
+2. More than 75 U.S. data-center projects worth ~$130B were blocked or
+   delayed in early 2026. Does that break the 194 GW-by-2035 demand path?
+3. Solar generated more U.S. electricity than coal in May 2026, the first
+   month on record. When does solar pass coal for a full year?
+
+Run the models with:
+
+```bash
+npm run news:2026-07-27
+```
+
+These are conditional, first-order experiments. The backstop model prices a
+deal that is still in negotiation; the attrition and crossover models
+project from anchors that include estimated (not final) 2025 figures.
+
+## Results at a glance
+
+| Story | Initial model | Failure exposed by the first pass | Revised result |
+|---|---|---|---|
+| Nvidia backstop | Divide the guarantee by the guarantor's revenue and compare to Lucent (24%), Nortel (10%), Cisco (11%) in 2000: Nvidia is at 116% alone, 278% with chip financing | A contingent lease guarantee is not a booked loan, and a ratio says nothing about absorption capacity or when the exposure could actually be called | Expected loss ~$25B ≈ 25% of one year of Nvidia FCF; a full call with collapsed GPU collateral ≈ 2.1 years of FCF. Earnings risk and circularity, not Lucent-style solvency risk |
+| Blocked data centers | Convert $130B to GW at facility cost, annualize: 47 GW/yr blocked vs 16 GW/yr required — "the forecast is infeasible" | Announced project values may include IT gear (3.7 vs 11.8 GW), blocked ≠ destroyed (phantom queue, relocation), and the forecast already absorbs ~24 GW/yr of queue attrition | Net consent drag 1.4–4.5 GW/yr of average load, comparable to the 1.5–5.3 GW/yr firm-capacity drag; both slow the path by years rather than breaking it |
+| Solar over coal | Read the May monthly crossover as the annual regime change: "solar overtook coal in 2026" | May is solar's ~1.20× month and coal's ~0.84× month; annual 2026 still has a ~190 TWh solar deficit | Annual crossover in 2028 (2028–2029 across coal sensitivities). The seasonal model reproduces the observed May 2026 values within 6–8% from 2025 anchors |
+
+## 1. The backstop is vendor financing — priced, it is an earnings risk
+
+The reported structure: Nvidia would guarantee ~$250B tied to the lease and
+construction debt of the $500B, 10 GW SB Energy campus in Piketon, Ohio that
+OpenAI would lease, with chip-purchase financing that could reach another
+$350B. Nvidia's FY2026 revenue was $215.9B and free cash flow $96.6B;
+OpenAI's annualized revenue is ~$25B.
+
+V1 reproduces the day's dominant take (the ratio):
+
+| Entity | Peak commitments / revenue |
+|---|---:|
+| Lucent FY2000 | 24.1% |
+| Nortel 2000 | 10.2% |
+| Cisco FY2001 | 10.8% |
+| Nvidia, backstop alone | 115.8% |
+| Nvidia, incl. chip financing | 277.9% |
+
+The intensity comparison is fair — this is 5× the worst vendor-financing
+ratio of the telecom bubble, from a single deal, for a single counterparty.
+
+V2 prices the guarantee instead of describing it:
+
+- **Serviceability.** At 8% over 15 years the full-build lease is ~$58B/yr,
+  requiring ~$195B of OpenAI revenue if this one campus can absorb 30% of a
+  compute budget. Reusing the AI capital-cycle model's monetization paths:
+  fast covers the lease by 2031, central by 2032 (about when full build
+  arrives), slow never does by 2036. The guarantee is a bet that the slow
+  path does not happen.
+- **Expected loss.** Weighting the three paths (25/50/25) with per-path call
+  probabilities (2%/15%/60%), 60% drawn at distress, and wrong-way recovery
+  (20% in the slow world, where GPU resale collapses exactly when the call
+  happens): expected loss ≈ $25B, about a quarter of one year of FCF.
+  Applying the telecom bust's realized loss rate (35% of peak commitments)
+  to the drawn exposure gives $53B — same order.
+- **Absorption.** A full $250B call with worst-case recovery is ~$200B, or
+  2.1 years of Nvidia FCF. Lucent's ~$3.5B of losses hit a company with
+  negative FCF; that difference is why the ratio alone misleads.
+
+Where the model differs from conventional wisdom: both popular readings are
+wrong in opposite directions. "Lucent redux" overstates solvency risk — a
+guarantee from a company generating ~$97B of FCF is absorbable. "It's only a
+contingency, non-cash" understates it — the deal concentrates a
+triple-digit-billion single-name exposure whose collateral (GPUs, AI-shell
+real estate) is worth least in the states of the world where the call
+happens, and 70% of the project capex flows back to the guarantor as chip
+revenue. The right frame is a large written put on OpenAI monetization,
+sold to finance demand for the writer's own product — earnings-cyclical,
+circular, but not balance-sheet-fatal.
+
+Sources: [Reuters/WSJ on the talks](https://finance.yahoo.com/technology/ai/articles/nvidia-talks-openai-guarantee-250-233930971.html),
+[project details](https://www.networkworld.com/article/4183513/openai-weighs-nvidia-backed-lease-for-10-gw-ohio-data-center-campus.html),
+[telecom vendor-financing history](https://tomtunguz.com/nvidia_nortel_vendor_financing_comparison/),
+[Nortel drawn balances](https://www.theglobeandmail.com/report-on-business/nortel-clients-give-warning-of-finances/article20454748/),
+[Nvidia FY2026 results](https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-fourth-quarter-and-fiscal-2026),
+and [OpenAI revenue](https://sacra.com/c/openai/).
+
+## 2. $130B blocked is a consent story, and smaller in GW than it sounds
+
+Data Center Watch's count — 75+ projects, ~$130B, first three months of
+2026 — is widely quoted next to "power shortage" framing. The tracker
+itself attributes the blocks to local opposition: zoning denials,
+moratoria, and at least 69 local bans.
+
+V1 does the alarmed arithmetic: $130B ÷ $11B/GW ≈ 11.8 GW per quarter ≈
+47 GW/yr, three times the 15.9 GW/yr the BloombergNEF 35→194 GW path needs.
+Forecast infeasible.
+
+V2 fixes three accounting problems and then asks which constraint binds:
+
+1. **Capex semantics.** Announced "project value" sometimes includes IT
+   equipment. The same $130B is 11.8 GW at facility-only cost ($11B/GW) but
+   3.7 GW at full-stack cost ($35B/GW).
+2. **Blocked ≠ destroyed.** A blocked proposal only removes demand if it
+   would have materialized (utility queues realize ~40% of large-load
+   requests) and does not resite (an estimated 60% relocate). Net loss:
+   2.4–7.6 GW/yr of capacity, or 1.4–4.5 GW/yr of average load.
+3. **The forecast already absorbs attrition.** Hitting 15.9 GW/yr net at 40%
+   queue realization implies ~24 GW/yr of proposals failing anyway. Observed
+   gross blocking (~130% of that budget) is elevated but the queue is
+   deliberately oversubscribed.
+
+The existing data-center-grid model then supplies the competing constraint:
+if only 60 GW of shared firm capacity gets built by 2035 against the
+socialized-scenario requirement of ~144 GW, unserved average load is
+~53 GW — a 5.3 GW/yr drag, larger than consent. With 120 GW built the gap
+is ~15 GW (1.5 GW/yr), smaller than the consent channel's upper bound.
+
+| Channel | Average-load drag (GW/yr) |
+|---|---:|
+| Consent, net of phantoms and relocation | 1.4–4.5 |
+| Firm capacity, 60 GW shared build | 5.3 |
+| Firm capacity, 120 GW shared build | 1.5 |
+
+Where the model differs from conventional wisdom: the "power shortage
+blocked $130B of AI" framing misattributes a consent phenomenon, and the
+literal GW subtraction overstates it by roughly an order of magnitude. But
+the sanguine reading ("phantom queue, nothing real was lost") is also
+wrong: consent drag at the observed rate is the same size as a plausible
+firm-capacity shortfall, and the two channels compound — enough to push
+the 2035 path years late even though neither breaks it.
+
+Sources: [Data Center Watch tally](https://www.prnewswire.com/news-releases/130-billion-in-ai-data-centers-have-been-blocked-or-delayed-in-2026-302821568.html),
+[coverage with attribution to local opposition](https://www.tomshardware.com/tech-industry/artificial-intelligence/more-than-75-data-center-build-outs-worth-usd130-billion-have-been-successfully-blocked-in-the-first-four-months-of-2026-bipartisan-opposition-mounts-nationwide-over-fears-of-soaring-power-and-water-costs),
+and [the BNEF 2035 forecast](https://www.bloomberg.com/news/articles/2026-07-21/data-centers-on-track-to-suck-up-a-fifth-of-us-power-use-by-2035).
+
+## 3. Solar passed coal in May; the annual crossover is ~2028
+
+Ember's milestone is real: May 2026 solar 45.5 TWh (12.8% of generation)
+versus coal 43.4 TWh (12.2%), the first month on record with solar above
+coal. The headline reading treats this as the crossover.
+
+V2 separates season from trend:
+
+- May seasonal factors derived from 2025 anchors (solar ~390 TWh, coal
+  ~700 TWh estimated): solar's May runs 1.20× its average month, coal's
+  0.84×.
+- One-step validation: projecting 2025 annuals forward one year and applying
+  those factors predicts May 2026 at 48.1 TWh solar vs 46.8 TWh coal —
+  within 6–8% of the observed values, and correctly reproducing the monthly
+  crossover.
+- Annual projection: solar adds ~92 TWh/yr (44 GW of 2026 solar additions at
+  a 24% capacity factor), additions growing 5%/yr; coal declines 4%/yr
+  centrally (0 to −8% sensitivity, reflecting demand growth propping coal
+  against retirements).
+
+| Year | Solar TWh | Coal TWh |
+|---|---:|---:|
+| 2026 | 482 | 672 |
+| 2027 | 579 | 645 |
+| 2028 | 680 | 619 |
+| 2029 | 787 | 595 |
+
+The first full solar-over-coal year is 2028 centrally, 2029 if coal holds
+flat, and 2029–2030 if solar additions stall at ~70 TWh/yr. The monthly
+milestone leads the annual crossover by about two years — the same pattern
+as wind, which passed coal in monthly data in April 2019 but has still not
+passed it on an annual basis in years when coal rebounds.
+
+World-model tie-in: the repository's baseline scenario puts the *global*
+solar-over-coal electricity crossover at 2034 — the US story leads the
+world by roughly six years, mostly because Asian coal fleets are young.
+
+Where the model differs from conventional wisdom: "solar has overtaken
+coal" is premature by ~2 years as an annual claim for the US (2026 still
+carries a ~190 TWh annual deficit), but the direction is overdetermined —
+no plausible coal path avoids the crossover by 2030. The more durable
+correction runs the other way: coal generation *rose* in 2025–2026 on gas
+prices and demand growth even while its share fell, so share milestones say
+little about absolute emissions in the near term.
+
+Sources: [Ember on the May crossover](https://ember-energy.org/latest-updates/solar-overtakes-coal-in-us-electricity-for-the-first-month-on-record/),
+[EIA 2026 planned additions](https://pv-magazine-usa.com/2026/07/22/solar-and-storage-account-for-91-of-new-u-s-grid-capacity-in-first-half-of-2026/),
+and [EIA 2025 generation record](https://www.eia.gov/todayinenergy/detail.php?id=67284).
+
+## What most differs from conventional wisdom
+
+1. **Nvidia backstop:** the telecom-bubble ratio comparison is directionally
+   fair and quantitatively unprecedented, but the failure mode is different:
+   circular, concentrated earnings risk with wrong-way collateral — not the
+   thin-balance-sheet solvency spiral of 2001. Watch the call probability
+   (OpenAI monetization), not the notional.
+2. **Blocked data centers:** consent, not electrons, is what blocked $130B —
+   and correctly accounted, consent and firm capacity are similar-sized
+   drags that delay rather than derail the 2035 demand path.
+3. **Solar vs coal:** a seasonal first is two years ahead of the annual
+   fact; and because coal output is currently rising with demand, the
+   crossover is a share story, not yet an emissions story.
+
+Code:
+`src/simulations/news/headline-experiments-2026-07-27.ts`.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "trade:network": "node --import tsx scripts/trade-network-tariff-scenario.ts",
     "news:2026-07-24": "node --import tsx scripts/headlines-2026-07-24.ts",
     "news:2026-07-25": "node --import tsx scripts/headlines-2026-07-25.ts",
-    "news:2026-07-26": "node --import tsx scripts/headlines-2026-07-26.ts"
+    "news:2026-07-26": "node --import tsx scripts/headlines-2026-07-26.ts",
+    "news:2026-07-27": "node --import tsx scripts/headlines-2026-07-27.ts"
   },
   "engines": {
     "node": ">=20"

--- a/scripts/headlines-2026-07-27.ts
+++ b/scripts/headlines-2026-07-27.ts
@@ -1,0 +1,179 @@
+import { runSimulation } from '../src/index.js';
+import {
+  evaluatePipelineAttrition,
+  evaluateSolarCoalCrossover,
+  evaluateVendorFinancingBackstop,
+} from '../src/simulations/news/headline-experiments-2026-07-27.js';
+
+const pct = (value: number): string => `${(100 * value).toFixed(1)}%`;
+const billions = (value: number): string => `$${value.toFixed(0)}B`;
+const gw = (value: number): string => `${value.toFixed(1)} GW`;
+
+console.log('=== News-driven simulations: 2026-07-27 ===\n');
+console.log('Selected questions');
+console.table([
+  {
+    headline: "Nvidia weighs $250B backstop for OpenAI's 10 GW Ohio campus",
+    estimand: 'vendor-financing exposure and expected loss',
+    mechanism: 'contingent guarantee × monetization × wrong-way collateral',
+  },
+  {
+    headline: '$130B of data centers blocked or delayed in early 2026',
+    estimand: 'net drag on the 194 GW-by-2035 path',
+    mechanism: 'capex semantics × relocation × queue phantoms vs firm capacity',
+  },
+  {
+    headline: 'Solar passed coal in US electricity for the first month ever',
+    estimand: 'year of the first full-year solar-over-coal crossover',
+    mechanism: 'May seasonality × addition-driven solar growth × coal decline',
+  },
+]);
+
+// ---------------------------------------------------------------------------
+const backstop = evaluateVendorFinancingBackstop();
+console.log('\n1. Nvidia backstop as vendor financing');
+console.table([
+  ...backstop.initialV1.benchmarkShares.map((row) => ({
+    entity: row.id,
+    'commitments / revenue': pct(row.commitmentsShareOfRevenue),
+  })),
+  {
+    entity: 'nvidia backstop alone',
+    'commitments / revenue': pct(backstop.initialV1.backstopShareOfRevenue),
+  },
+  {
+    entity: 'nvidia incl. chip financing',
+    'commitments / revenue': pct(
+      backstop.initialV1.totalDiscussedShareOfRevenue,
+    ),
+  },
+]);
+console.log(
+  `V1: the guarantee alone is ${backstop.initialV1.multipleOfLargestHistoricalRatio.toFixed(
+    1,
+  )}x Lucent's peak vendor-financing intensity — the "Lucent redux" reading.`,
+);
+console.table(
+  backstop.revisedV2.scenarioCoverage.map((row) => ({
+    scenario: row.id,
+    weight: row.weight,
+    'P(call)': pct(row.callProbability),
+    'revenue 2032': billions(row.projectedRevenueBillion2032),
+    'covers lease in': row.coverageYear ?? 'never (by 2036)',
+  })),
+);
+console.log(
+  `V2: the full-build lease is ${billions(
+    backstop.revisedV2.fullBuildAnnualLeasePaymentBillion,
+  )}/yr, needing ~${billions(
+    backstop.revisedV2.requiredLesseeRevenueBillion,
+  )} of lessee revenue. Probability-weighted expected loss ${billions(
+    backstop.revisedV2.expectedLossBillion,
+  )} (${pct(
+    backstop.revisedV2.expectedLossShareOfAnnualFreeCashFlow,
+  )} of one year's FCF); telecom-analog loss ${billions(
+    backstop.revisedV2.telecomAnalogLossBillion,
+  )}; worst case ${billions(
+    backstop.revisedV2.worstCaseLossBillion,
+  )} = ${backstop.revisedV2.worstCaseLossYearsOfFreeCashFlow.toFixed(
+    1,
+  )} years of FCF. ${pct(
+    backstop.revisedV2.guaranteedBuyerShareOfProjectCapex,
+  )} of project capex is chips sold by the guarantor.`,
+);
+
+// ---------------------------------------------------------------------------
+const attrition = evaluatePipelineAttrition();
+console.log('\n2. Blocked data centers vs the 2035 path');
+console.log(
+  `V1: ${gw(
+    attrition.initialV1.annualizedBlockedGwPerYear,
+  )}/yr annualized blocked vs ${gw(
+    attrition.requiredNetAdditionsGwPerYear,
+  )}/yr required -> "forecast infeasible" (${String(
+    attrition.initialV1.forecastLooksInfeasible,
+  )}).`,
+);
+console.table([
+  {
+    channel: 'consent (net of phantoms + relocation)',
+    'avg-load drag GW/yr':
+      `${attrition.revisedV2.consentDragAverageLoadGwPerYearLow.toFixed(1)}-` +
+      attrition.revisedV2.consentDragAverageLoadGwPerYearHigh.toFixed(1),
+  },
+  ...attrition.revisedV2.firmCapacityVariants.map((row) => ({
+    channel: `firm capacity (${row.sharedFirmBuildGw} GW shared build)`,
+    'avg-load drag GW/yr':
+      row.firmCapacityDragAverageLoadGwPerYear.toFixed(1),
+  })),
+]);
+console.log(
+  `V2: the $130B is ${gw(attrition.revisedV2.blockedGwFullStack)}-${gw(
+    attrition.revisedV2.blockedGwFacilityOnly,
+  )} depending on whether announced value includes IT gear; gross blocking runs ${pct(
+    attrition.revisedV2.grossBlockedShareOfEmbeddedAttrition,
+  )} of the queue attrition the forecast already absorbs. Binding constraint: ${
+    attrition.revisedV2.bindingConstraint
+  }.`,
+);
+
+// ---------------------------------------------------------------------------
+const crossover = evaluateSolarCoalCrossover();
+console.log('\n3. Solar vs coal: monthly milestone, annual crossover');
+console.log(
+  `V1: May 2026 solar/coal = ${crossover.initialV1.may2026SolarShareOfCoal.toFixed(
+    2,
+  )} -> "solar overtook coal in ${crossover.initialV1.claimedCrossoverYear}".`,
+);
+console.table(
+  crossover.revisedV2.annualSeries.slice(0, 5).map((row) => ({
+    year: row.year,
+    'solar TWh': Math.round(row.solarTwh),
+    'coal TWh': Math.round(row.coalTwh),
+  })),
+);
+console.log(
+  `V2: seasonal factors (May solar ${crossover.revisedV2.maySolarSeasonalFactor.toFixed(
+    2,
+  )}x, May coal ${crossover.revisedV2.mayCoalSeasonalFactor.toFixed(
+    2,
+  )}x) predict May 2026 at ${crossover.revisedV2.predictedMay2026SolarTwh.toFixed(
+    1,
+  )} vs ${crossover.revisedV2.predictedMay2026CoalTwh.toFixed(
+    1,
+  )} TWh (errors ${pct(crossover.revisedV2.may2026SolarPredictionError)}, ${pct(
+    crossover.revisedV2.may2026CoalPredictionError,
+  )}) and reproduce the monthly crossover. Annual crossover: ${String(
+    crossover.revisedV2.annualCrossoverYear,
+  )} (coal-decline sensitivity ${String(
+    crossover.revisedV2.annualCrossoverYearCoalDeclineLow,
+  )}-${String(
+    crossover.revisedV2.annualCrossoverYearCoalDeclineHigh,
+  )}); 2026 still has a ${crossover.revisedV2.annual2026SolarDeficitTwh.toFixed(
+    0,
+  )} TWh annual solar deficit.`,
+);
+
+// World-model comparison: the main simulation's global solar-vs-coal
+// electricity crossover, for contrast with the US-only story.
+const world = runSimulation();
+const worldCrossover = world.results.find(
+  (row) =>
+    (row.generation.solar ?? 0) > (row.generation.coal ?? 0),
+);
+console.log(
+  `World model tie-in: the baseline scenario's global electricity mix first puts solar above coal in ${
+    worldCrossover ? worldCrossover.year : 'no year in the horizon'
+  } (US-only stories lead the world by years).`,
+);
+
+console.log('\nWhere the models differ from conventional wisdom');
+console.log(
+  '- Nvidia backstop: the "Lucent redux" ratio is real - 5x the worst 2000 vendor-financing intensity, 12x including chip financing. But a priced contingency is not a booked loan: the expected loss is about a quarter of one year of free cash flow, and even a full call with collapsed GPU collateral is ~2 years of FCF - an earnings event, not a solvency event. The novel risk is concentration and circularity (70% of the project capex is chips sold by the guarantor), not the balance-sheet fragility that killed Lucent.',
+);
+console.log(
+  '- Blocked data centers: the $130B figure is consent, not a power shortage - and it is gross project value at announcement, so the GW at stake are 3-12 GW, not a year of the demand path. After phantoms and relocation, consent drag and firm-capacity drag are the same order of magnitude; neither alone breaks the 194 GW path, but together they are the difference between BNEF 2035 arriving on time and arriving ~2-4 years late.',
+);
+console.log(
+  '- Solar vs coal: the May milestone is real but seasonal - solar runs ~1.2x its annual-average month in May while coal runs ~0.84x. On current addition rates the annual crossover lands in 2028 (2028-2029 under coal sensitivity), so "solar has overtaken coal" is about two years early as an annual claim - and the baseline world model puts the same global crossover around 2034, six years behind the US.',
+);

--- a/scripts/headlines-2026-07-27.ts
+++ b/scripts/headlines-2026-07-27.ts
@@ -54,13 +54,19 @@ console.log(
   )}x Lucent's peak vendor-financing intensity — the "Lucent redux" reading.`,
 );
 console.table(
-  backstop.revisedV2.scenarioCoverage.map((row) => ({
-    scenario: row.id,
-    weight: row.weight,
-    'P(call)': pct(row.callProbability),
-    'revenue 2032': billions(row.projectedRevenueBillion2032),
-    'covers lease in': row.coverageYear ?? 'never (by 2036)',
-  })),
+  backstop.revisedV2.scenarioCoverage.map((row, index) => {
+    const scenario = backstop.case.monetizationScenarios[index];
+    return {
+      scenario: row.id,
+      weight: scenario?.weight ?? NaN,
+      'P(call)': pct(scenario?.callProbability ?? NaN),
+      [`revenue ${backstop.case.revenueReportYear}`]: billions(
+        row.projectedRevenueAtReportYearBillion,
+      ),
+      'covers lease in':
+        row.coverageYear ?? `never (by ${backstop.revisedV2.projectionEndYear})`,
+    };
+  }),
 );
 console.log(
   `V2: the full-build lease is ${billions(

--- a/src/simulations/news/headline-experiments-2026-07-27.test.ts
+++ b/src/simulations/news/headline-experiments-2026-07-27.test.ts
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  evaluatePipelineAttrition,
+  evaluateSolarCoalCrossover,
+  evaluateVendorFinancingBackstop,
+  solarCoalCrossoverCase,
+} from './headline-experiments-2026-07-27.js';
+
+test('vendor backstop dwarfs telecom ratios but prices as a survivable contingency', () => {
+  const result = evaluateVendorFinancingBackstop();
+
+  assert.ok(result.initialV1.backstopShareOfRevenue > 1.1);
+  assert.ok(result.initialV1.backstopShareOfRevenue < 1.2);
+  assert.ok(result.initialV1.multipleOfLargestHistoricalRatio > 4);
+  assert.ok(result.initialV1.multipleOfLargestHistoricalRatio < 6);
+  assert.ok(result.initialV1.totalDiscussedShareOfRevenue > 2.5);
+
+  assert.ok(result.revisedV2.fullBuildAnnualLeasePaymentBillion > 50);
+  assert.ok(result.revisedV2.fullBuildAnnualLeasePaymentBillion < 70);
+  assert.ok(result.revisedV2.requiredLesseeRevenueBillion > 180);
+  assert.ok(result.revisedV2.requiredLesseeRevenueBillion < 210);
+
+  const byId = new Map(
+    result.revisedV2.scenarioCoverage.map((row) => [row.id, row]),
+  );
+  assert.equal(byId.get('slow-monetization')?.coverageYear, null);
+  const centralCoverage = byId.get('central')?.coverageYear;
+  assert.ok(centralCoverage !== null && centralCoverage !== undefined);
+  assert.ok(centralCoverage >= 2031 && centralCoverage <= 2033);
+
+  assert.ok(result.revisedV2.expectedLossBillion > 15);
+  assert.ok(result.revisedV2.expectedLossBillion < 35);
+  assert.ok(result.revisedV2.expectedLossShareOfAnnualFreeCashFlow < 0.4);
+  assert.ok(result.revisedV2.worstCaseLossYearsOfFreeCashFlow > 1.5);
+  assert.ok(result.revisedV2.worstCaseLossYearsOfFreeCashFlow < 3);
+  assert.ok(result.revisedV2.historicalLossShareOfCommitments > 0.3);
+  assert.ok(result.revisedV2.historicalLossShareOfCommitments < 0.4);
+  assert.ok(result.revisedV2.guaranteedBuyerShareOfProjectCapex > 0.6);
+});
+
+test('pipeline attrition shrinks from fatal to comparable once semantics are fixed', () => {
+  const result = evaluatePipelineAttrition();
+
+  assert.ok(result.requiredNetAdditionsGwPerYear > 15);
+  assert.ok(result.requiredNetAdditionsGwPerYear < 17);
+  assert.ok(result.initialV1.forecastLooksInfeasible);
+  assert.ok(result.initialV1.annualizedBlockedGwPerYear > 40);
+
+  assert.ok(result.revisedV2.blockedGwFullStack < 4);
+  assert.ok(result.revisedV2.blockedGwFacilityOnly > 10);
+  assert.ok(result.revisedV2.netCapacityLossGwPerYearHigh < 8);
+  assert.ok(result.revisedV2.netCapacityLossGwPerYearLow > 2);
+  assert.ok(result.revisedV2.consentDragAverageLoadGwPerYearHigh < 5);
+  assert.ok(result.revisedV2.grossBlockedShareOfEmbeddedAttrition > 1);
+  assert.ok(result.revisedV2.grossBlockedShareOfEmbeddedAttrition < 1.6);
+
+  const drags = result.revisedV2.firmCapacityVariants.map(
+    (row) => row.firmCapacityDragAverageLoadGwPerYear,
+  );
+  assert.ok(Math.min(...drags) < 2);
+  assert.ok(Math.max(...drags) > 5);
+  assert.equal(result.revisedV2.bindingConstraint, 'comparable');
+});
+
+test('solar-coal revision validates on May 2026 and moves the crossover to 2028', () => {
+  const result = evaluateSolarCoalCrossover();
+
+  assert.equal(result.initialV1.claimedCrossoverYear, 2026);
+  assert.ok(result.initialV1.may2026SolarShareOfCoal > 1);
+
+  assert.ok(result.revisedV2.maySolarSeasonalFactor > 1.1);
+  assert.ok(result.revisedV2.maySolarSeasonalFactor < 1.3);
+  assert.ok(result.revisedV2.mayCoalSeasonalFactor > 0.75);
+  assert.ok(result.revisedV2.mayCoalSeasonalFactor < 0.9);
+  assert.ok(result.revisedV2.predictionReproducesMonthlyCrossover);
+  assert.ok(Math.abs(result.revisedV2.may2026SolarPredictionError) < 0.1);
+  assert.ok(Math.abs(result.revisedV2.may2026CoalPredictionError) < 0.1);
+
+  assert.equal(result.revisedV2.annualCrossoverYear, 2028);
+  assert.equal(result.revisedV2.annualCrossoverYearCoalDeclineLow, 2028);
+  assert.equal(result.revisedV2.annualCrossoverYearCoalDeclineHigh, 2029);
+  assert.ok(result.revisedV2.monthlyLeadYears !== null);
+  assert.ok(result.revisedV2.monthlyLeadYears >= 2);
+  assert.ok(result.revisedV2.annual2026SolarDeficitTwh > 150);
+});
+
+test('solar-coal crossover responds to slower solar additions', () => {
+  const slow = evaluateSolarCoalCrossover({
+    ...solarCoalCrossoverCase,
+    solarAnnualAdditionTwh: 70,
+    solarAdditionGrowth: 0,
+    coalAnnualGrowth: -0.02,
+  });
+  const crossover = slow.revisedV2.annualCrossoverYear;
+  assert.ok(crossover !== null);
+  assert.ok(crossover >= 2029);
+});

--- a/src/simulations/news/headline-experiments-2026-07-27.ts
+++ b/src/simulations/news/headline-experiments-2026-07-27.ts
@@ -1,10 +1,18 @@
-import { assertFiniteDeep, validateNumber } from 'tsimulation';
+import { assertFiniteDeep, validateNumber, validateShares } from 'tsimulation';
 
+import { capitalRecoveryFactor } from '../../modules/energy.js';
 import { aiCapitalCycleScenarios } from './ai-capital-cycle.js';
 import {
+  dataCenterGridEvidence,
   dataCenterGridScenarios,
   simulateDataCenterGrid,
 } from './data-center-grid.js';
+
+function throwIfInvalid(label: string, errors: readonly string[]): void {
+  if (errors.length > 0) {
+    throw new Error(`Invalid ${label}:\n  ${errors.join('\n  ')}`);
+  }
+}
 
 // ---------------------------------------------------------------------------
 // 1. Nvidia's $250B lease backstop as vendor financing
@@ -33,13 +41,16 @@ export interface VendorBackstopCase {
   /** Separately discussed chip-purchase financing. */
   chipFinancingBillion: number;
   projectCapexBillion: number;
-  projectGw: number;
   /** Vendor (guarantor) trailing annual revenue, $ billions. */
   vendorRevenueBillion: number;
   /** Vendor trailing annual free cash flow, $ billions. */
   vendorFreeCashFlowBillion: number;
   /** Beneficiary (lessee) current annualized revenue, $ billions. */
   lesseeAnnualizedRevenueBillion: number;
+  /** Calendar year of that annualized revenue; growth paths start here. */
+  revenuePathStartYear: number;
+  /** Year whose projected run-rate the result reports for each scenario. */
+  revenueReportYear: number;
   /** Financing rate applied to the leased project. */
   leaseFinancingRate: number;
   /** Amortization term of the lease, years. */
@@ -86,14 +97,16 @@ export interface VendorBackstopResult {
     fullBuildAnnualLeasePaymentBillion: number;
     /** Lessee revenue needed to fit the lease inside the campus budget. */
     requiredLesseeRevenueBillion: number;
+    /** Last calendar year the scenario revenue paths cover. */
+    projectionEndYear: number;
     scenarioCoverage: readonly {
       id: string;
-      weight: number;
-      callProbability: number;
       /** Calendar year revenue first covers the lease, or null. */
       coverageYear: number | null;
-      projectedRevenueBillion2032: number;
+      projectedRevenueAtReportYearBillion: number;
     }[];
+    /** How much of peak commitments the telecoms actually drew. */
+    historicalDrawnShareOfCommitments: number;
     expectedLossBillion: number;
     worstCaseLossBillion: number;
     expectedLossShareOfAnnualFreeCashFlow: number;
@@ -113,13 +126,16 @@ export const vendorBackstopCase: VendorBackstopCase = {
   // with chip-purchase financing that could total another $350B.
   backstopGuaranteeBillion: 250,
   chipFinancingBillion: 350,
-  projectCapexBillion: 500,
-  projectGw: 10,
+  projectCapexBillion: 500, // 10 GW campus, ~$50B/GW including compute
   // Nvidia FY2026 (ended Jan 2026): revenue $215.9B, FCF $96.6B.
   vendorRevenueBillion: 215.9,
   vendorFreeCashFlowBillion: 96.6,
   // OpenAI annualized revenue ~ $25B in early 2026 (Sacra; WSJ reporting).
   lesseeAnnualizedRevenueBillion: 25,
+  // The growth paths below are reused from the AI capital-cycle model and
+  // are dated from its start year.
+  revenuePathStartYear: aiCapitalCycleScenarios.central.startYear,
+  revenueReportYear: 2032,
   leaseFinancingRate: 0.08, // BBB-ish infrastructure debt plus spread
   leaseTermYears: 15,
   // One campus cannot absorb the lessee's whole compute budget: Piketon is
@@ -214,20 +230,19 @@ function validateVendorBackstopCase(input: VendorBackstopCase): void {
       min: 0,
       max: 1,
     }),
+    ...validateNumber(input.revenueReportYear, 'revenueReportYear', {
+      integer: true,
+      min: input.revenuePathStartYear,
+    }),
+    ...validateShares(
+      input.monetizationScenarios.map((scenario) => scenario.weight),
+      'monetization scenario weights',
+    ),
   ];
   if (input.benchmarks.length === 0) {
     errors.push('benchmarks must not be empty');
   }
-  const totalWeight = input.monetizationScenarios.reduce(
-    (sum, scenario) => sum + scenario.weight,
-    0,
-  );
-  if (Math.abs(totalWeight - 1) > 1e-9) {
-    errors.push(`monetization scenario weights must sum to 1, got ${totalWeight}`);
-  }
-  if (errors.length > 0) {
-    throw new Error(`Invalid vendor-backstop case:\n  ${errors.join('\n  ')}`);
-  }
+  throwIfInvalid('vendor-backstop case', errors);
 }
 
 /**
@@ -257,35 +272,53 @@ export function evaluateVendorFinancingBackstop(
     input.backstopGuaranteeBillion / input.vendorRevenueBillion;
 
   // Annuity payment on the leased project at full build.
-  const rate = input.leaseFinancingRate;
-  const annuityFactor =
-    rate / (1 - Math.pow(1 + rate, -input.leaseTermYears));
   const fullBuildAnnualLeasePaymentBillion =
-    input.projectCapexBillion * annuityFactor;
+    input.projectCapexBillion *
+    capitalRecoveryFactor(input.leaseFinancingRate, input.leaseTermYears);
   const requiredLesseeRevenueBillion =
     fullBuildAnnualLeasePaymentBillion / input.campusRevenueBudgetShare;
 
-  const startYear = 2026;
+  // Years are end-of-year run-rates: applying the first growth entry to the
+  // start-year revenue gives the start year's closing run-rate, matching the
+  // convention of the AI capital-cycle model the paths come from.
   const scenarioCoverage = input.monetizationScenarios.map((scenario) => {
-    let revenue = input.lesseeAnnualizedRevenueBillion;
-    let coverageYear: number | null = null;
-    let revenue2032 = revenue;
-    scenario.revenueGrowthPath.forEach((growth, index) => {
-      revenue *= 1 + growth;
-      const year = startYear + index + 1;
-      if (coverageYear === null && revenue >= requiredLesseeRevenueBillion) {
-        coverageYear = year;
-      }
-      if (year === 2032) revenue2032 = revenue;
-    });
+    const series = scenario.revenueGrowthPath.reduce<
+      { year: number; revenueBillion: number }[]
+    >((rows, growth, index) => {
+      const previous =
+        rows[rows.length - 1]?.revenueBillion ??
+        input.lesseeAnnualizedRevenueBillion;
+      rows.push({
+        year: input.revenuePathStartYear + index,
+        revenueBillion: previous * (1 + growth),
+      });
+      return rows;
+    }, []);
+    const reportRow = series.find(
+      (row) => row.year === input.revenueReportYear,
+    );
+    if (!reportRow) {
+      throw new Error(
+        `revenueReportYear ${input.revenueReportYear} is outside scenario ${scenario.id}'s projected years`,
+      );
+    }
     return {
       id: scenario.id,
-      weight: scenario.weight,
-      callProbability: scenario.callProbability,
-      coverageYear,
-      projectedRevenueBillion2032: revenue2032,
+      coverageYear:
+        series.find(
+          (row) => row.revenueBillion >= requiredLesseeRevenueBillion,
+        )?.year ?? null,
+      projectedRevenueAtReportYearBillion: reportRow.revenueBillion,
     };
   });
+  const projectionEndYear =
+    input.revenuePathStartYear +
+    Math.min(
+      ...input.monetizationScenarios.map(
+        (scenario) => scenario.revenueGrowthPath.length,
+      ),
+    ) -
+    1;
 
   const drawnExposureBillion =
     input.backstopGuaranteeBillion * input.exposureAtDistressShare;
@@ -306,6 +339,10 @@ export function evaluateVendorFinancingBackstop(
 
   const totalHistoricalLoss = input.benchmarks.reduce(
     (sum, benchmark) => sum + benchmark.realizedLossBillion,
+    0,
+  );
+  const totalHistoricalDrawn = input.benchmarks.reduce(
+    (sum, benchmark) => sum + benchmark.drawnBillion,
     0,
   );
   const totalHistoricalCommitments = input.benchmarks.reduce(
@@ -329,7 +366,10 @@ export function evaluateVendorFinancingBackstop(
     revisedV2: {
       fullBuildAnnualLeasePaymentBillion,
       requiredLesseeRevenueBillion,
+      projectionEndYear,
       scenarioCoverage,
+      historicalDrawnShareOfCommitments:
+        totalHistoricalDrawn / totalHistoricalCommitments,
       expectedLossBillion,
       worstCaseLossBillion,
       expectedLossShareOfAnnualFreeCashFlow:
@@ -352,9 +392,7 @@ export function evaluateVendorFinancingBackstop(
 // ---------------------------------------------------------------------------
 
 export interface PipelineAttritionCase {
-  /** Projects blocked or delayed by local opposition in early 2026. */
-  blockedProjects: number;
-  /** Announced value of those projects, $ billions (Data Center Watch). */
+  /** Announced value of blocked projects, $ billions (Data Center Watch). */
   blockedValueBillion: number;
   /** Months covered by the blocked-project count. */
   observationMonths: number;
@@ -373,6 +411,11 @@ export interface PipelineAttritionCase {
   relocationShare: number;
   /** Firm-capacity build variants fed to the shared-grid model, GW. */
   sharedFirmBuildVariantsGw: readonly number[];
+  /**
+   * One drag channel is called binding only when it exceeds the other by
+   * this ratio; anything closer is reported as comparable.
+   */
+  bindingConstraintRatioThreshold: number;
 }
 
 export interface PipelineAttritionResult {
@@ -410,8 +453,6 @@ export interface PipelineAttritionResult {
       /** That unserved 2035 load spread over the buildout, GW/year. */
       firmCapacityDragAverageLoadGwPerYear: number;
     }[];
-    /** Largest per-year firm-capacity drag across variants. */
-    maxFirmCapacityDragAverageLoadGwPerYear: number;
     bindingConstraint: 'firm-capacity' | 'consent' | 'comparable';
   };
 }
@@ -420,22 +461,25 @@ export const pipelineAttritionCase: PipelineAttritionCase = {
   // Data Center Watch via PRNewswire/Tom's Hardware, July 2026: >75
   // projects worth ~$130B blocked or delayed in the first three months of
   // 2026, attributed to local opposition — not to a grid shortage.
-  blockedProjects: 75,
   blockedValueBillion: 130,
   observationMonths: 3,
   // $10-12B/GW for land, shell, cooling, and power infrastructure;
   // $30-40B/GW when announced "project value" includes IT equipment.
   facilityCapexPerGwBillion: 11,
   fullStackCapexPerGwBillion: 35,
-  // BloombergNEF path used by the existing data-center-grid model.
-  currentCapacityGw: 35,
-  forecast2035CapacityGw: 194,
+  // BloombergNEF path, inherited from the anchors the data-center-grid
+  // model registers so a BNEF revision propagates here automatically.
+  currentCapacityGw: dataCenterGridEvidence.illustrativeCurrentCapacityGw,
+  forecast2035CapacityGw: dataCenterGridEvidence.bnef2035CapacityGw,
   forecastYears: 10,
   // Utility integrated-resource plans discount large-load queues heavily;
   // 30-60% realization is typical, 40% is the central reading.
   queueRealizationShare: 0.4,
   relocationShare: 0.6,
   sharedFirmBuildVariantsGw: [60, 120],
+  // Within 2x is "comparable": the drag estimates carry at least that much
+  // parameter uncertainty, so a finer verdict would be spurious precision.
+  bindingConstraintRatioThreshold: 2,
 };
 
 function validatePipelineAttritionCase(input: PipelineAttritionCase): void {
@@ -468,6 +512,11 @@ function validatePipelineAttritionCase(input: PipelineAttritionCase): void {
       integer: true,
       min: 1,
     }),
+    ...validateNumber(
+      input.bindingConstraintRatioThreshold,
+      'bindingConstraintRatioThreshold',
+      { min: 1 },
+    ),
   ];
   if (input.forecast2035CapacityGw <= input.currentCapacityGw) {
     errors.push('forecast2035CapacityGw must exceed currentCapacityGw');
@@ -475,9 +524,7 @@ function validatePipelineAttritionCase(input: PipelineAttritionCase): void {
   if (input.sharedFirmBuildVariantsGw.length === 0) {
     errors.push('sharedFirmBuildVariantsGw must not be empty');
   }
-  if (errors.length > 0) {
-    throw new Error(`Invalid pipeline-attrition case:\n  ${errors.join('\n  ')}`);
-  }
+  throwIfInvalid('pipeline-attrition case', errors);
 }
 
 /**
@@ -500,13 +547,13 @@ export function evaluatePipelineAttrition(
     (input.forecast2035CapacityGw - input.currentCapacityGw) /
     input.forecastYears;
 
-  const annualizationFactor = 12 / input.observationMonths;
+  const annualize = (gwPerObservation: number): number =>
+    gwPerObservation * 12 / input.observationMonths;
   const blockedGwFacilityOnly =
     input.blockedValueBillion / input.facilityCapexPerGwBillion;
   const blockedGwFullStack =
     input.blockedValueBillion / input.fullStackCapexPerGwBillion;
-  const annualizedBlockedGwPerYear =
-    blockedGwFacilityOnly * annualizationFactor;
+  const annualizedBlockedGwPerYear = annualize(blockedGwFacilityOnly);
 
   // A blocked proposal only destroys demand if it would have materialized
   // (queue realization) and does not simply resite (relocation).
@@ -515,7 +562,7 @@ export function evaluatePipelineAttrition(
   const netCapacityLossGwPerYearHigh =
     annualizedBlockedGwPerYear * netLossFactor;
   const netCapacityLossGwPerYearLow =
-    blockedGwFullStack * annualizationFactor * netLossFactor;
+    annualize(blockedGwFullStack) * netLossFactor;
 
   // If only queueRealizationShare of gross proposals materialize, hitting the
   // net path requires gross proposals of net / share; the difference is
@@ -523,8 +570,9 @@ export function evaluatePipelineAttrition(
   const embeddedQueueAttritionGwPerYear =
     requiredNetAdditionsGwPerYear / input.queueRealizationShare -
     requiredNetAdditionsGwPerYear;
-  const grossBlockedGwPerYearCentral =
-    ((blockedGwFacilityOnly + blockedGwFullStack) / 2) * annualizationFactor;
+  const grossBlockedGwPerYearCentral = annualize(
+    (blockedGwFacilityOnly + blockedGwFullStack) / 2,
+  );
 
   const socialized = dataCenterGridScenarios.socialized;
   if (!socialized) {
@@ -538,9 +586,11 @@ export function evaluatePipelineAttrition(
         label: `Shared firm build ${sharedFirmBuildGw} GW`,
         sharedFirmBuildGw,
       });
+      // Scale the peak-GW gap to average load by the model's own realized
+      // average-to-peak ratio so a change to that derivation propagates.
       const unservedAverageLoadGw =
-        run.reliabilityGapGw / socialized.peakCoincidenceFactor *
-        socialized.loadFactor;
+        run.reliabilityGapGw *
+        (run.realizedAverageLoadGw / run.coincidentPeakGw);
       return {
         sharedFirmBuildGw,
         reliabilityGapGw: run.reliabilityGapGw,
@@ -550,7 +600,7 @@ export function evaluatePipelineAttrition(
       };
     },
   );
-  const maxFirmCapacityDragAverageLoadGwPerYear = Math.max(
+  const maxFirmCapacityDrag = Math.max(
     ...firmCapacityVariants.map(
       (row) => row.firmCapacityDragAverageLoadGwPerYear,
     ),
@@ -563,10 +613,11 @@ export function evaluatePipelineAttrition(
   const consentDragCentral =
     (consentDragAverageLoadGwPerYearLow + consentDragAverageLoadGwPerYearHigh) /
     2;
+  const threshold = input.bindingConstraintRatioThreshold;
   const bindingConstraint =
-    maxFirmCapacityDragAverageLoadGwPerYear > 2 * consentDragCentral
+    maxFirmCapacityDrag > threshold * consentDragCentral
       ? 'firm-capacity'
-      : consentDragCentral > 2 * maxFirmCapacityDragAverageLoadGwPerYear
+      : consentDragCentral > threshold * maxFirmCapacityDrag
         ? 'consent'
         : 'comparable';
 
@@ -591,7 +642,6 @@ export function evaluatePipelineAttrition(
       grossBlockedShareOfEmbeddedAttrition:
         grossBlockedGwPerYearCentral / embeddedQueueAttritionGwPerYear,
       firmCapacityVariants,
-      maxFirmCapacityDragAverageLoadGwPerYear,
       bindingConstraint,
     },
   };
@@ -604,6 +654,10 @@ export function evaluatePipelineAttrition(
 // ---------------------------------------------------------------------------
 
 export interface SolarCoalCrossoverCase {
+  /** Calendar year of the annual anchors; projections start the next year. */
+  anchorYear: number;
+  /** Year of the observed monthly (May) crossover. */
+  monthlyCrossoverYear: number;
   may2026SolarTwh: number;
   may2026CoalTwh: number;
   /** May-over-May growth implied by the same Ember release. */
@@ -658,6 +712,8 @@ export interface SolarCoalCrossoverResult {
 }
 
 export const solarCoalCrossoverCase: SolarCoalCrossoverCase = {
+  anchorYear: 2025,
+  monthlyCrossoverYear: 2026,
   // Ember, June-July 2026: May 2026 solar 45.5 TWh (12.8% share) vs coal
   // 43.4 TWh (12.2%) — the first month on record with solar above coal.
   may2026SolarTwh: 45.5,
@@ -712,10 +768,23 @@ function validateSolarCoalCase(input: SolarCoalCrossoverCase): void {
       min: input.coalAnnualGrowthLow,
       max: input.coalAnnualGrowthHigh,
     }),
+    ...validateNumber(input.monthlyCrossoverYear, 'monthlyCrossoverYear', {
+      integer: true,
+      min: input.anchorYear,
+    }),
   ];
-  if (errors.length > 0) {
-    throw new Error(`Invalid solar-coal crossover case:\n  ${errors.join('\n  ')}`);
+  // The prior-year anchors exist to guard the estimated current-year
+  // anchors against transcription errors, not to drive the projection.
+  if (input.annual2025SolarTwh <= input.annual2024SolarTwh) {
+    errors.push('annual2025SolarTwh must exceed annual2024SolarTwh');
   }
+  if (
+    input.annual2025CoalTwh < 0.8 * input.annual2024CoalTwh ||
+    input.annual2025CoalTwh > 1.2 * input.annual2024CoalTwh
+  ) {
+    errors.push('annual2025CoalTwh must be within 20% of annual2024CoalTwh');
+  }
+  throwIfInvalid('solar-coal crossover case', errors);
 }
 
 function annualCrossover(
@@ -731,7 +800,7 @@ function annualCrossover(
   let addition = input.solarAnnualAdditionTwh;
   let crossoverYear: number | null = null;
   for (let offset = 1; offset <= input.horizonYears; offset++) {
-    const year = 2025 + offset;
+    const year = input.anchorYear + offset;
     solar += addition;
     addition *= 1 + input.solarAdditionGrowth;
     coal *= 1 + coalGrowth;
@@ -781,7 +850,7 @@ export function evaluateSolarCoalCrossover(
   const result: SolarCoalCrossoverResult = {
     case: input,
     initialV1: {
-      claimedCrossoverYear: 2026,
+      claimedCrossoverYear: input.monthlyCrossoverYear,
       may2026SolarShareOfCoal: input.may2026SolarTwh / input.may2026CoalTwh,
     },
     revisedV2: {
@@ -800,7 +869,9 @@ export function evaluateSolarCoalCrossover(
       annualCrossoverYearCoalDeclineLow: low.crossoverYear,
       annualCrossoverYearCoalDeclineHigh: high.crossoverYear,
       monthlyLeadYears:
-        central.crossoverYear === null ? null : central.crossoverYear - 2026,
+        central.crossoverYear === null
+          ? null
+          : central.crossoverYear - input.monthlyCrossoverYear,
       annual2026SolarDeficitTwh: annual2026.coalTwh - annual2026.solarTwh,
     },
   };
@@ -808,8 +879,8 @@ export function evaluateSolarCoalCrossover(
   return result;
 }
 
-export const headlineEvidence20260727 = {
-  sources: {
+export const july27HeadlineEvidence = {
+  backstop: {
     nvidiaBackstop:
       'https://finance.yahoo.com/technology/ai/articles/nvidia-talks-openai-guarantee-250-233930971.html',
     piketonProject:
@@ -821,12 +892,16 @@ export const headlineEvidence20260727 = {
     nvidiaFy2026:
       'https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-fourth-quarter-and-fiscal-2026',
     openAiRevenue: 'https://sacra.com/c/openai/',
+  },
+  dataCenters: {
     blockedProjects:
       'https://www.prnewswire.com/news-releases/130-billion-in-ai-data-centers-have-been-blocked-or-delayed-in-2026-302821568.html',
     blockedProjectsDetail:
       'https://www.tomshardware.com/tech-industry/artificial-intelligence/more-than-75-data-center-build-outs-worth-usd130-billion-have-been-successfully-blocked-in-the-first-four-months-of-2026-bipartisan-opposition-mounts-nationwide-over-fears-of-soaring-power-and-water-costs',
     bnefForecast:
       'https://www.bloomberg.com/news/articles/2026-07-21/data-centers-on-track-to-suck-up-a-fifth-of-us-power-use-by-2035',
+  },
+  solarCoal: {
     emberMayCrossover:
       'https://ember-energy.org/latest-updates/solar-overtakes-coal-in-us-electricity-for-the-first-month-on-record/',
     eia2026Additions:

--- a/src/simulations/news/headline-experiments-2026-07-27.ts
+++ b/src/simulations/news/headline-experiments-2026-07-27.ts
@@ -1,0 +1,837 @@
+import { assertFiniteDeep, validateNumber } from 'tsimulation';
+
+import { aiCapitalCycleScenarios } from './ai-capital-cycle.js';
+import {
+  dataCenterGridScenarios,
+  simulateDataCenterGrid,
+} from './data-center-grid.js';
+
+// ---------------------------------------------------------------------------
+// 1. Nvidia's $250B lease backstop as vendor financing
+// ---------------------------------------------------------------------------
+
+export interface VendorFinancingBenchmark {
+  id: string;
+  label: string;
+  /** Peak announced customer-financing commitments, $ billions. */
+  commitmentsBillion: number;
+  /** Commitments actually drawn near the peak, $ billions. */
+  drawnBillion: number;
+  /** Vendor annual revenue in the peak year, $ billions. */
+  revenueBillion: number;
+  /**
+   * Approximate realized credit losses and write-downs through the bust,
+   * $ billions. These are order-of-magnitude figures assembled from filings
+   * and contemporaneous reporting, not audited totals.
+   */
+  realizedLossBillion: number;
+}
+
+export interface VendorBackstopCase {
+  /** Reported guarantee under discussion for lease and construction debt. */
+  backstopGuaranteeBillion: number;
+  /** Separately discussed chip-purchase financing. */
+  chipFinancingBillion: number;
+  projectCapexBillion: number;
+  projectGw: number;
+  /** Vendor (guarantor) trailing annual revenue, $ billions. */
+  vendorRevenueBillion: number;
+  /** Vendor trailing annual free cash flow, $ billions. */
+  vendorFreeCashFlowBillion: number;
+  /** Beneficiary (lessee) current annualized revenue, $ billions. */
+  lesseeAnnualizedRevenueBillion: number;
+  /** Financing rate applied to the leased project. */
+  leaseFinancingRate: number;
+  /** Amortization term of the lease, years. */
+  leaseTermYears: number;
+  /** Share of lessee revenue that can be budgeted to this one campus. */
+  campusRevenueBudgetShare: number;
+  /** Share of the guarantee assumed drawn when distress would surface. */
+  exposureAtDistressShare: number;
+  benchmarks: readonly VendorFinancingBenchmark[];
+  monetizationScenarios: readonly VendorMonetizationScenario[];
+}
+
+export interface VendorMonetizationScenario {
+  id: string;
+  /** Probability weight of the scenario. */
+  weight: number;
+  /** Lessee annual revenue growth path, reused as a monetization prior. */
+  revenueGrowthPath: readonly number[];
+  /** Probability the guarantee is called within the scenario. */
+  callProbability: number;
+  /**
+   * Recovery on the drawn guarantee if called. Low in slow-monetization
+   * worlds because the collateral is GPUs and AI shells whose resale value
+   * collapses exactly when calls happen (wrong-way risk).
+   */
+  recoveryShare: number;
+}
+
+export interface VendorBackstopResult {
+  case: VendorBackstopCase;
+  initialV1: {
+    /** Guarantee alone over vendor revenue. */
+    backstopShareOfRevenue: number;
+    /** Guarantee plus chip financing over vendor revenue. */
+    totalDiscussedShareOfRevenue: number;
+    benchmarkShares: readonly {
+      id: string;
+      commitmentsShareOfRevenue: number;
+    }[];
+    /** How many times the largest historical ratio the backstop alone is. */
+    multipleOfLargestHistoricalRatio: number;
+  };
+  revisedV2: {
+    fullBuildAnnualLeasePaymentBillion: number;
+    /** Lessee revenue needed to fit the lease inside the campus budget. */
+    requiredLesseeRevenueBillion: number;
+    scenarioCoverage: readonly {
+      id: string;
+      weight: number;
+      callProbability: number;
+      /** Calendar year revenue first covers the lease, or null. */
+      coverageYear: number | null;
+      projectedRevenueBillion2032: number;
+    }[];
+    expectedLossBillion: number;
+    worstCaseLossBillion: number;
+    expectedLossShareOfAnnualFreeCashFlow: number;
+    worstCaseLossYearsOfFreeCashFlow: number;
+    /** Telecom-bust realized losses as a share of peak commitments. */
+    historicalLossShareOfCommitments: number;
+    /** That historical loss share applied to the drawn Nvidia exposure. */
+    telecomAnalogLossBillion: number;
+    /** Chip financing over project capex: how circular the revenue is. */
+    guaranteedBuyerShareOfProjectCapex: number;
+  };
+}
+
+export const vendorBackstopCase: VendorBackstopCase = {
+  // WSJ via Reuters, 26 July 2026: talks to guarantee ~$250B tied to the
+  // lease and construction debt of SB Energy's 10 GW Piketon, Ohio campus,
+  // with chip-purchase financing that could total another $350B.
+  backstopGuaranteeBillion: 250,
+  chipFinancingBillion: 350,
+  projectCapexBillion: 500,
+  projectGw: 10,
+  // Nvidia FY2026 (ended Jan 2026): revenue $215.9B, FCF $96.6B.
+  vendorRevenueBillion: 215.9,
+  vendorFreeCashFlowBillion: 96.6,
+  // OpenAI annualized revenue ~ $25B in early 2026 (Sacra; WSJ reporting).
+  lesseeAnnualizedRevenueBillion: 25,
+  leaseFinancingRate: 0.08, // BBB-ish infrastructure debt plus spread
+  leaseTermYears: 15,
+  // One campus cannot absorb the lessee's whole compute budget: Piketon is
+  // ~10 GW of an announced multi-site pipeline several times larger.
+  campusRevenueBudgetShare: 0.30,
+  // First 800 MW phase targeted for 2028; distress in a slow-monetization
+  // world would surface mid-build, not at full draw.
+  exposureAtDistressShare: 0.60,
+  benchmarks: [
+    {
+      id: 'lucent-2000',
+      label: 'Lucent FY2000',
+      commitmentsBillion: 8.1, // widely cited peak commitment figure
+      drawnBillion: 1.6,
+      revenueBillion: 33.6,
+      realizedLossBillion: 3.5, // FY2001 customer-financing provisions
+    },
+    {
+      id: 'nortel-2000',
+      label: 'Nortel 2000',
+      commitmentsBillion: 3.1,
+      drawnBillion: 1.4, // Globe and Mail, 2001
+      revenueBillion: 30.3,
+      realizedLossBillion: 1.0,
+    },
+    {
+      id: 'cisco-2001',
+      label: 'Cisco FY2001',
+      commitmentsBillion: 2.4,
+      drawnBillion: 0.6,
+      revenueBillion: 22.3,
+      realizedLossBillion: 0.3,
+    },
+  ],
+  monetizationScenarios: [
+    {
+      id: 'fast-monetization',
+      weight: 0.25,
+      revenueGrowthPath:
+        aiCapitalCycleScenarios['fast-monetization'].annualRevenueGrowthPath,
+      callProbability: 0.02,
+      recoveryShare: 0.55,
+    },
+    {
+      id: 'central',
+      weight: 0.5,
+      revenueGrowthPath: aiCapitalCycleScenarios.central.annualRevenueGrowthPath,
+      callProbability: 0.15,
+      recoveryShare: 0.45,
+    },
+    {
+      id: 'slow-monetization',
+      weight: 0.25,
+      revenueGrowthPath:
+        aiCapitalCycleScenarios['slow-monetization'].annualRevenueGrowthPath,
+      callProbability: 0.60,
+      recoveryShare: 0.20,
+    },
+  ],
+};
+
+function validateVendorBackstopCase(input: VendorBackstopCase): void {
+  assertFiniteDeep(input, 'vendor-backstop case');
+  const errors = [
+    ...validateNumber(input.backstopGuaranteeBillion, 'backstopGuaranteeBillion', {
+      min: 0,
+      exclusiveMin: true,
+    }),
+    ...validateNumber(input.vendorRevenueBillion, 'vendorRevenueBillion', {
+      min: 0,
+      exclusiveMin: true,
+    }),
+    ...validateNumber(input.vendorFreeCashFlowBillion, 'vendorFreeCashFlowBillion', {
+      min: 0,
+      exclusiveMin: true,
+    }),
+    ...validateNumber(input.leaseFinancingRate, 'leaseFinancingRate', {
+      min: 0,
+      exclusiveMin: true,
+      max: 0.3,
+    }),
+    ...validateNumber(input.leaseTermYears, 'leaseTermYears', {
+      integer: true,
+      min: 1,
+    }),
+    ...validateNumber(input.campusRevenueBudgetShare, 'campusRevenueBudgetShare', {
+      min: 0,
+      exclusiveMin: true,
+      max: 1,
+    }),
+    ...validateNumber(input.exposureAtDistressShare, 'exposureAtDistressShare', {
+      min: 0,
+      max: 1,
+    }),
+  ];
+  if (input.benchmarks.length === 0) {
+    errors.push('benchmarks must not be empty');
+  }
+  const totalWeight = input.monetizationScenarios.reduce(
+    (sum, scenario) => sum + scenario.weight,
+    0,
+  );
+  if (Math.abs(totalWeight - 1) > 1e-9) {
+    errors.push(`monetization scenario weights must sum to 1, got ${totalWeight}`);
+  }
+  if (errors.length > 0) {
+    throw new Error(`Invalid vendor-backstop case:\n  ${errors.join('\n  ')}`);
+  }
+}
+
+/**
+ * Evaluates the reported Nvidia guarantee of OpenAI's Piketon lease as
+ * vendor financing.
+ *
+ * V1 is the headline test: divide the guarantee by the guarantor's revenue
+ * and compare to Lucent, Nortel, and Cisco in 2000. V2 keeps the comparison
+ * but prices the guarantee as a contingent exposure: lease serviceability
+ * under monetization scenarios, an expected loss with wrong-way collateral
+ * recovery, and absorption capacity measured in years of free cash flow.
+ */
+export function evaluateVendorFinancingBackstop(
+  input: VendorBackstopCase = vendorBackstopCase,
+): VendorBackstopResult {
+  validateVendorBackstopCase(input);
+
+  const benchmarkShares = input.benchmarks.map((benchmark) => ({
+    id: benchmark.id,
+    commitmentsShareOfRevenue:
+      benchmark.commitmentsBillion / benchmark.revenueBillion,
+  }));
+  const largestHistoricalRatio = Math.max(
+    ...benchmarkShares.map((row) => row.commitmentsShareOfRevenue),
+  );
+  const backstopShareOfRevenue =
+    input.backstopGuaranteeBillion / input.vendorRevenueBillion;
+
+  // Annuity payment on the leased project at full build.
+  const rate = input.leaseFinancingRate;
+  const annuityFactor =
+    rate / (1 - Math.pow(1 + rate, -input.leaseTermYears));
+  const fullBuildAnnualLeasePaymentBillion =
+    input.projectCapexBillion * annuityFactor;
+  const requiredLesseeRevenueBillion =
+    fullBuildAnnualLeasePaymentBillion / input.campusRevenueBudgetShare;
+
+  const startYear = 2026;
+  const scenarioCoverage = input.monetizationScenarios.map((scenario) => {
+    let revenue = input.lesseeAnnualizedRevenueBillion;
+    let coverageYear: number | null = null;
+    let revenue2032 = revenue;
+    scenario.revenueGrowthPath.forEach((growth, index) => {
+      revenue *= 1 + growth;
+      const year = startYear + index + 1;
+      if (coverageYear === null && revenue >= requiredLesseeRevenueBillion) {
+        coverageYear = year;
+      }
+      if (year === 2032) revenue2032 = revenue;
+    });
+    return {
+      id: scenario.id,
+      weight: scenario.weight,
+      callProbability: scenario.callProbability,
+      coverageYear,
+      projectedRevenueBillion2032: revenue2032,
+    };
+  });
+
+  const drawnExposureBillion =
+    input.backstopGuaranteeBillion * input.exposureAtDistressShare;
+  const expectedLossBillion = input.monetizationScenarios.reduce(
+    (sum, scenario) =>
+      sum +
+      scenario.weight *
+        scenario.callProbability *
+        drawnExposureBillion *
+        (1 - scenario.recoveryShare),
+    0,
+  );
+  const worstRecovery = Math.min(
+    ...input.monetizationScenarios.map((scenario) => scenario.recoveryShare),
+  );
+  const worstCaseLossBillion =
+    input.backstopGuaranteeBillion * (1 - worstRecovery);
+
+  const totalHistoricalLoss = input.benchmarks.reduce(
+    (sum, benchmark) => sum + benchmark.realizedLossBillion,
+    0,
+  );
+  const totalHistoricalCommitments = input.benchmarks.reduce(
+    (sum, benchmark) => sum + benchmark.commitmentsBillion,
+    0,
+  );
+  const historicalLossShareOfCommitments =
+    totalHistoricalLoss / totalHistoricalCommitments;
+
+  const result: VendorBackstopResult = {
+    case: input,
+    initialV1: {
+      backstopShareOfRevenue,
+      totalDiscussedShareOfRevenue:
+        (input.backstopGuaranteeBillion + input.chipFinancingBillion) /
+        input.vendorRevenueBillion,
+      benchmarkShares,
+      multipleOfLargestHistoricalRatio:
+        backstopShareOfRevenue / largestHistoricalRatio,
+    },
+    revisedV2: {
+      fullBuildAnnualLeasePaymentBillion,
+      requiredLesseeRevenueBillion,
+      scenarioCoverage,
+      expectedLossBillion,
+      worstCaseLossBillion,
+      expectedLossShareOfAnnualFreeCashFlow:
+        expectedLossBillion / input.vendorFreeCashFlowBillion,
+      worstCaseLossYearsOfFreeCashFlow:
+        worstCaseLossBillion / input.vendorFreeCashFlowBillion,
+      historicalLossShareOfCommitments,
+      telecomAnalogLossBillion:
+        historicalLossShareOfCommitments * drawnExposureBillion,
+      guaranteedBuyerShareOfProjectCapex:
+        Math.min(1, input.chipFinancingBillion / input.projectCapexBillion),
+    },
+  };
+  assertFiniteDeep(result, 'vendor-backstop result');
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// 2. $130B of blocked data centers versus the 2035 demand path
+// ---------------------------------------------------------------------------
+
+export interface PipelineAttritionCase {
+  /** Projects blocked or delayed by local opposition in early 2026. */
+  blockedProjects: number;
+  /** Announced value of those projects, $ billions (Data Center Watch). */
+  blockedValueBillion: number;
+  /** Months covered by the blocked-project count. */
+  observationMonths: number;
+  /** Facility-plus-power capex per GW when IT equipment is excluded. */
+  facilityCapexPerGwBillion: number;
+  /** Full-stack project value per GW when announced values include IT gear. */
+  fullStackCapexPerGwBillion: number;
+  /** Operating data-center capacity at the start of the forecast, GW. */
+  currentCapacityGw: number;
+  /** Forecast capacity in 2035, GW (BloombergNEF). */
+  forecast2035CapacityGw: number;
+  forecastYears: number;
+  /** Share of contracted interconnection requests that ever materialize. */
+  queueRealizationShare: number;
+  /** Share of consent-blocked demand that resites within a year or two. */
+  relocationShare: number;
+  /** Firm-capacity build variants fed to the shared-grid model, GW. */
+  sharedFirmBuildVariantsGw: readonly number[];
+}
+
+export interface PipelineAttritionResult {
+  case: PipelineAttritionCase;
+  requiredNetAdditionsGwPerYear: number;
+  initialV1: {
+    /** Blocked GW annualized, using facility-only $/GW. */
+    annualizedBlockedGwPerYear: number;
+    /** Required additions minus blocked additions, taken literally. */
+    naiveRemainingAdditionsGwPerYear: number;
+    forecastLooksInfeasible: boolean;
+  };
+  revisedV2: {
+    /** The same $130B translated under both capex-semantics readings. */
+    blockedGwFacilityOnly: number;
+    blockedGwFullStack: number;
+    /**
+     * Annualized capacity actually lost to blocking after discounting for
+     * queue phantoms and relocation, GW/year (full-stack vs facility-only).
+     */
+    netCapacityLossGwPerYearLow: number;
+    netCapacityLossGwPerYearHigh: number;
+    /** The same net loss expressed as average served load, GW/year. */
+    consentDragAverageLoadGwPerYearLow: number;
+    consentDragAverageLoadGwPerYearHigh: number;
+    /** Gross proposals the forecast already expects to fail, GW/year. */
+    embeddedQueueAttritionGwPerYear: number;
+    /** Gross annualized blocked capacity vs that embedded failure budget. */
+    grossBlockedShareOfEmbeddedAttrition: number;
+    firmCapacityVariants: readonly {
+      sharedFirmBuildGw: number;
+      reliabilityGapGw: number;
+      /** Contracted average load that cannot be served firmly, GW. */
+      unservedAverageLoadGw: number;
+      /** That unserved 2035 load spread over the buildout, GW/year. */
+      firmCapacityDragAverageLoadGwPerYear: number;
+    }[];
+    /** Largest per-year firm-capacity drag across variants. */
+    maxFirmCapacityDragAverageLoadGwPerYear: number;
+    bindingConstraint: 'firm-capacity' | 'consent' | 'comparable';
+  };
+}
+
+export const pipelineAttritionCase: PipelineAttritionCase = {
+  // Data Center Watch via PRNewswire/Tom's Hardware, July 2026: >75
+  // projects worth ~$130B blocked or delayed in the first three months of
+  // 2026, attributed to local opposition — not to a grid shortage.
+  blockedProjects: 75,
+  blockedValueBillion: 130,
+  observationMonths: 3,
+  // $10-12B/GW for land, shell, cooling, and power infrastructure;
+  // $30-40B/GW when announced "project value" includes IT equipment.
+  facilityCapexPerGwBillion: 11,
+  fullStackCapexPerGwBillion: 35,
+  // BloombergNEF path used by the existing data-center-grid model.
+  currentCapacityGw: 35,
+  forecast2035CapacityGw: 194,
+  forecastYears: 10,
+  // Utility integrated-resource plans discount large-load queues heavily;
+  // 30-60% realization is typical, 40% is the central reading.
+  queueRealizationShare: 0.4,
+  relocationShare: 0.6,
+  sharedFirmBuildVariantsGw: [60, 120],
+};
+
+function validatePipelineAttritionCase(input: PipelineAttritionCase): void {
+  assertFiniteDeep(input, 'pipeline-attrition case');
+  const errors = [
+    ...validateNumber(input.blockedValueBillion, 'blockedValueBillion', {
+      min: 0,
+      exclusiveMin: true,
+    }),
+    ...validateNumber(input.observationMonths, 'observationMonths', {
+      min: 1,
+      max: 12,
+    }),
+    ...validateNumber(input.facilityCapexPerGwBillion, 'facilityCapexPerGwBillion', {
+      min: 0,
+      exclusiveMin: true,
+    }),
+    ...validateNumber(
+      input.fullStackCapexPerGwBillion,
+      'fullStackCapexPerGwBillion',
+      { min: input.facilityCapexPerGwBillion },
+    ),
+    ...validateNumber(input.queueRealizationShare, 'queueRealizationShare', {
+      min: 0,
+      exclusiveMin: true,
+      max: 1,
+    }),
+    ...validateNumber(input.relocationShare, 'relocationShare', { min: 0, max: 1 }),
+    ...validateNumber(input.forecastYears, 'forecastYears', {
+      integer: true,
+      min: 1,
+    }),
+  ];
+  if (input.forecast2035CapacityGw <= input.currentCapacityGw) {
+    errors.push('forecast2035CapacityGw must exceed currentCapacityGw');
+  }
+  if (input.sharedFirmBuildVariantsGw.length === 0) {
+    errors.push('sharedFirmBuildVariantsGw must not be empty');
+  }
+  if (errors.length > 0) {
+    throw new Error(`Invalid pipeline-attrition case:\n  ${errors.join('\n  ')}`);
+  }
+}
+
+/**
+ * Puts the "$130B of AI data centers blocked" figure against the BloombergNEF
+ * demand path the existing grid model uses.
+ *
+ * V1 does what the alarmed reading does: convert dollars to GW, annualize,
+ * and subtract from the required additions. V2 fixes three accounting
+ * errors — the $/GW semantics of announced project values, relocation of
+ * blocked demand, and the phantom share of the interconnection queue — and
+ * then asks the existing data-center-grid model which constraint actually
+ * binds.
+ */
+export function evaluatePipelineAttrition(
+  input: PipelineAttritionCase = pipelineAttritionCase,
+): PipelineAttritionResult {
+  validatePipelineAttritionCase(input);
+
+  const requiredNetAdditionsGwPerYear =
+    (input.forecast2035CapacityGw - input.currentCapacityGw) /
+    input.forecastYears;
+
+  const annualizationFactor = 12 / input.observationMonths;
+  const blockedGwFacilityOnly =
+    input.blockedValueBillion / input.facilityCapexPerGwBillion;
+  const blockedGwFullStack =
+    input.blockedValueBillion / input.fullStackCapexPerGwBillion;
+  const annualizedBlockedGwPerYear =
+    blockedGwFacilityOnly * annualizationFactor;
+
+  // A blocked proposal only destroys demand if it would have materialized
+  // (queue realization) and does not simply resite (relocation).
+  const netLossFactor =
+    input.queueRealizationShare * (1 - input.relocationShare);
+  const netCapacityLossGwPerYearHigh =
+    annualizedBlockedGwPerYear * netLossFactor;
+  const netCapacityLossGwPerYearLow =
+    blockedGwFullStack * annualizationFactor * netLossFactor;
+
+  // If only queueRealizationShare of gross proposals materialize, hitting the
+  // net path requires gross proposals of net / share; the difference is
+  // attrition the forecast already absorbs.
+  const embeddedQueueAttritionGwPerYear =
+    requiredNetAdditionsGwPerYear / input.queueRealizationShare -
+    requiredNetAdditionsGwPerYear;
+  const grossBlockedGwPerYearCentral =
+    ((blockedGwFacilityOnly + blockedGwFullStack) / 2) * annualizationFactor;
+
+  const socialized = dataCenterGridScenarios.socialized;
+  if (!socialized) {
+    throw new Error('data-center-grid socialized scenario is missing');
+  }
+  const firmCapacityVariants = input.sharedFirmBuildVariantsGw.map(
+    (sharedFirmBuildGw) => {
+      const run = simulateDataCenterGrid({
+        ...socialized,
+        id: `attrition-${sharedFirmBuildGw}`,
+        label: `Shared firm build ${sharedFirmBuildGw} GW`,
+        sharedFirmBuildGw,
+      });
+      const unservedAverageLoadGw =
+        run.reliabilityGapGw / socialized.peakCoincidenceFactor *
+        socialized.loadFactor;
+      return {
+        sharedFirmBuildGw,
+        reliabilityGapGw: run.reliabilityGapGw,
+        unservedAverageLoadGw,
+        firmCapacityDragAverageLoadGwPerYear:
+          unservedAverageLoadGw / input.forecastYears,
+      };
+    },
+  );
+  const maxFirmCapacityDragAverageLoadGwPerYear = Math.max(
+    ...firmCapacityVariants.map(
+      (row) => row.firmCapacityDragAverageLoadGwPerYear,
+    ),
+  );
+
+  const consentDragAverageLoadGwPerYearLow =
+    netCapacityLossGwPerYearLow * socialized.loadFactor;
+  const consentDragAverageLoadGwPerYearHigh =
+    netCapacityLossGwPerYearHigh * socialized.loadFactor;
+  const consentDragCentral =
+    (consentDragAverageLoadGwPerYearLow + consentDragAverageLoadGwPerYearHigh) /
+    2;
+  const bindingConstraint =
+    maxFirmCapacityDragAverageLoadGwPerYear > 2 * consentDragCentral
+      ? 'firm-capacity'
+      : consentDragCentral > 2 * maxFirmCapacityDragAverageLoadGwPerYear
+        ? 'consent'
+        : 'comparable';
+
+  const result: PipelineAttritionResult = {
+    case: input,
+    requiredNetAdditionsGwPerYear,
+    initialV1: {
+      annualizedBlockedGwPerYear,
+      naiveRemainingAdditionsGwPerYear:
+        requiredNetAdditionsGwPerYear - annualizedBlockedGwPerYear,
+      forecastLooksInfeasible:
+        annualizedBlockedGwPerYear > requiredNetAdditionsGwPerYear,
+    },
+    revisedV2: {
+      blockedGwFacilityOnly,
+      blockedGwFullStack,
+      netCapacityLossGwPerYearLow,
+      netCapacityLossGwPerYearHigh,
+      consentDragAverageLoadGwPerYearLow,
+      consentDragAverageLoadGwPerYearHigh,
+      embeddedQueueAttritionGwPerYear,
+      grossBlockedShareOfEmbeddedAttrition:
+        grossBlockedGwPerYearCentral / embeddedQueueAttritionGwPerYear,
+      firmCapacityVariants,
+      maxFirmCapacityDragAverageLoadGwPerYear,
+      bindingConstraint,
+    },
+  };
+  assertFiniteDeep(result, 'pipeline-attrition result');
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// 3. Solar passed coal in May. When does it pass coal for a full year?
+// ---------------------------------------------------------------------------
+
+export interface SolarCoalCrossoverCase {
+  may2026SolarTwh: number;
+  may2026CoalTwh: number;
+  /** May-over-May growth implied by the same Ember release. */
+  maySolarYearOverYearGrowth: number;
+  mayCoalYearOverYearGrowth: number;
+  /** EIA annual anchors. 2025 values are estimates pending final data. */
+  annual2024SolarTwh: number;
+  annual2024CoalTwh: number;
+  annual2025SolarTwh: number;
+  annual2025CoalTwh: number;
+  /** Absolute solar generation added per year going forward, TWh. */
+  solarAnnualAdditionTwh: number;
+  /** Yearly growth of that absolute addition (learning + record capacity). */
+  solarAdditionGrowth: number;
+  /** Annual change in coal generation (negative is decline). */
+  coalAnnualGrowth: number;
+  /** Sensitivity bounds for coal's annual change. */
+  coalAnnualGrowthLow: number;
+  coalAnnualGrowthHigh: number;
+  horizonYears: number;
+}
+
+export interface SolarCoalCrossoverResult {
+  case: SolarCoalCrossoverCase;
+  initialV1: {
+    /** Reading the monthly crossover as the annual regime change. */
+    claimedCrossoverYear: number;
+    may2026SolarShareOfCoal: number;
+  };
+  revisedV2: {
+    /** Seasonal factors derived from May 2025 vs annual 2025. */
+    maySolarSeasonalFactor: number;
+    mayCoalSeasonalFactor: number;
+    /** One-step validation: predicted May 2026 from 2025 anchors. */
+    predictedMay2026SolarTwh: number;
+    predictedMay2026CoalTwh: number;
+    may2026SolarPredictionError: number;
+    may2026CoalPredictionError: number;
+    predictionReproducesMonthlyCrossover: boolean;
+    annualSeries: readonly {
+      year: number;
+      solarTwh: number;
+      coalTwh: number;
+    }[];
+    annualCrossoverYear: number | null;
+    annualCrossoverYearCoalDeclineLow: number | null;
+    annualCrossoverYearCoalDeclineHigh: number | null;
+    /** Years between the first monthly crossover and the annual one. */
+    monthlyLeadYears: number | null;
+    annual2026SolarDeficitTwh: number;
+  };
+}
+
+export const solarCoalCrossoverCase: SolarCoalCrossoverCase = {
+  // Ember, June-July 2026: May 2026 solar 45.5 TWh (12.8% share) vs coal
+  // 43.4 TWh (12.2%) — the first month on record with solar above coal.
+  may2026SolarTwh: 45.5,
+  may2026CoalTwh: 43.4,
+  maySolarYearOverYearGrowth: 0.17,
+  mayCoalYearOverYearGrowth: -0.11,
+  // EIA: solar 239 TWh (2023) -> 303 TWh (2024); coal 653 TWh (2024).
+  annual2024SolarTwh: 303,
+  annual2024CoalTwh: 653,
+  // 2025 estimates: solar ~+29% on another record build year; coal rose on
+  // higher gas prices and demand growth to roughly 700 TWh (EIA STEO).
+  annual2025SolarTwh: 390,
+  annual2025CoalTwh: 700,
+  // EIA planned 2026 additions: 86 GW, 51% solar. 44 GW at a 24% capacity
+  // factor is ~92 TWh of new annual output.
+  solarAnnualAdditionTwh: 92,
+  solarAdditionGrowth: 0.05,
+  coalAnnualGrowth: -0.04,
+  coalAnnualGrowthLow: -0.08,
+  coalAnnualGrowthHigh: 0,
+  horizonYears: 10,
+};
+
+function validateSolarCoalCase(input: SolarCoalCrossoverCase): void {
+  assertFiniteDeep(input, 'solar-coal crossover case');
+  const errors = [
+    ...validateNumber(input.may2026SolarTwh, 'may2026SolarTwh', {
+      min: 0,
+      exclusiveMin: true,
+    }),
+    ...validateNumber(input.may2026CoalTwh, 'may2026CoalTwh', {
+      min: 0,
+      exclusiveMin: true,
+    }),
+    ...validateNumber(input.annual2025SolarTwh, 'annual2025SolarTwh', {
+      min: 0,
+      exclusiveMin: true,
+    }),
+    ...validateNumber(input.annual2025CoalTwh, 'annual2025CoalTwh', {
+      min: 0,
+      exclusiveMin: true,
+    }),
+    ...validateNumber(input.solarAnnualAdditionTwh, 'solarAnnualAdditionTwh', {
+      min: 0,
+      exclusiveMin: true,
+    }),
+    ...validateNumber(input.horizonYears, 'horizonYears', {
+      integer: true,
+      min: 1,
+    }),
+    ...validateNumber(input.coalAnnualGrowth, 'coalAnnualGrowth', {
+      min: input.coalAnnualGrowthLow,
+      max: input.coalAnnualGrowthHigh,
+    }),
+  ];
+  if (errors.length > 0) {
+    throw new Error(`Invalid solar-coal crossover case:\n  ${errors.join('\n  ')}`);
+  }
+}
+
+function annualCrossover(
+  input: SolarCoalCrossoverCase,
+  coalGrowth: number,
+): {
+  series: { year: number; solarTwh: number; coalTwh: number }[];
+  crossoverYear: number | null;
+} {
+  const series: { year: number; solarTwh: number; coalTwh: number }[] = [];
+  let solar = input.annual2025SolarTwh;
+  let coal = input.annual2025CoalTwh;
+  let addition = input.solarAnnualAdditionTwh;
+  let crossoverYear: number | null = null;
+  for (let offset = 1; offset <= input.horizonYears; offset++) {
+    const year = 2025 + offset;
+    solar += addition;
+    addition *= 1 + input.solarAdditionGrowth;
+    coal *= 1 + coalGrowth;
+    series.push({ year, solarTwh: solar, coalTwh: coal });
+    if (crossoverYear === null && solar > coal) crossoverYear = year;
+  }
+  return { series, crossoverYear };
+}
+
+/**
+ * Separates the May 2026 monthly solar-over-coal milestone from the annual
+ * crossover it is widely read as.
+ *
+ * V1 is the headline reading: solar "overtook" coal in 2026. V2 derives May
+ * seasonal factors from the 2025 anchors, validates them by predicting the
+ * observed May 2026 values one year ahead, and then projects annual series
+ * to find the full-year crossover and its sensitivity to coal's decline
+ * rate.
+ */
+export function evaluateSolarCoalCrossover(
+  input: SolarCoalCrossoverCase = solarCoalCrossoverCase,
+): SolarCoalCrossoverResult {
+  validateSolarCoalCase(input);
+
+  const may2025SolarTwh =
+    input.may2026SolarTwh / (1 + input.maySolarYearOverYearGrowth);
+  const may2025CoalTwh =
+    input.may2026CoalTwh / (1 + input.mayCoalYearOverYearGrowth);
+  const maySolarSeasonalFactor =
+    may2025SolarTwh / (input.annual2025SolarTwh / 12);
+  const mayCoalSeasonalFactor =
+    may2025CoalTwh / (input.annual2025CoalTwh / 12);
+
+  const central = annualCrossover(input, input.coalAnnualGrowth);
+  const [annual2026] = central.series;
+  if (!annual2026) {
+    throw new Error('crossover projection produced no years');
+  }
+  const predictedMay2026SolarTwh =
+    (annual2026.solarTwh / 12) * maySolarSeasonalFactor;
+  const predictedMay2026CoalTwh =
+    (annual2026.coalTwh / 12) * mayCoalSeasonalFactor;
+
+  const low = annualCrossover(input, input.coalAnnualGrowthLow);
+  const high = annualCrossover(input, input.coalAnnualGrowthHigh);
+
+  const result: SolarCoalCrossoverResult = {
+    case: input,
+    initialV1: {
+      claimedCrossoverYear: 2026,
+      may2026SolarShareOfCoal: input.may2026SolarTwh / input.may2026CoalTwh,
+    },
+    revisedV2: {
+      maySolarSeasonalFactor,
+      mayCoalSeasonalFactor,
+      predictedMay2026SolarTwh,
+      predictedMay2026CoalTwh,
+      may2026SolarPredictionError:
+        predictedMay2026SolarTwh / input.may2026SolarTwh - 1,
+      may2026CoalPredictionError:
+        predictedMay2026CoalTwh / input.may2026CoalTwh - 1,
+      predictionReproducesMonthlyCrossover:
+        predictedMay2026SolarTwh > predictedMay2026CoalTwh,
+      annualSeries: central.series,
+      annualCrossoverYear: central.crossoverYear,
+      annualCrossoverYearCoalDeclineLow: low.crossoverYear,
+      annualCrossoverYearCoalDeclineHigh: high.crossoverYear,
+      monthlyLeadYears:
+        central.crossoverYear === null ? null : central.crossoverYear - 2026,
+      annual2026SolarDeficitTwh: annual2026.coalTwh - annual2026.solarTwh,
+    },
+  };
+  assertFiniteDeep(result, 'solar-coal crossover result');
+  return result;
+}
+
+export const headlineEvidence20260727 = {
+  sources: {
+    nvidiaBackstop:
+      'https://finance.yahoo.com/technology/ai/articles/nvidia-talks-openai-guarantee-250-233930971.html',
+    piketonProject:
+      'https://www.networkworld.com/article/4183513/openai-weighs-nvidia-backed-lease-for-10-gw-ohio-data-center-campus.html',
+    lucentNortelVendorFinancing:
+      'https://tomtunguz.com/nvidia_nortel_vendor_financing_comparison/',
+    nortelDrawn:
+      'https://www.theglobeandmail.com/report-on-business/nortel-clients-give-warning-of-finances/article20454748/',
+    nvidiaFy2026:
+      'https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-fourth-quarter-and-fiscal-2026',
+    openAiRevenue: 'https://sacra.com/c/openai/',
+    blockedProjects:
+      'https://www.prnewswire.com/news-releases/130-billion-in-ai-data-centers-have-been-blocked-or-delayed-in-2026-302821568.html',
+    blockedProjectsDetail:
+      'https://www.tomshardware.com/tech-industry/artificial-intelligence/more-than-75-data-center-build-outs-worth-usd130-billion-have-been-successfully-blocked-in-the-first-four-months-of-2026-bipartisan-opposition-mounts-nationwide-over-fears-of-soaring-power-and-water-costs',
+    bnefForecast:
+      'https://www.bloomberg.com/news/articles/2026-07-21/data-centers-on-track-to-suck-up-a-fifth-of-us-power-use-by-2035',
+    emberMayCrossover:
+      'https://ember-energy.org/latest-updates/solar-overtakes-coal-in-us-electricity-for-the-first-month-on-record/',
+    eia2026Additions:
+      'https://pv-magazine-usa.com/2026/07/22/solar-and-storage-account-for-91-of-new-u-s-grid-capacity-in-first-half-of-2026/',
+    eia2025Generation:
+      'https://www.eia.gov/todayinenergy/detail.php?id=67284',
+  },
+} as const;


### PR DESCRIPTION
Daily news-modeling pass for 27 July 2026. Three stories with a measurable estimand, each modeled twice (naive V1, revised V2), documented in `docs/NEWS_STRESS_TESTS_2026-07-27.md`, runnable via `npm run news:2026-07-27`.

## 1. Nvidia's reported $250B backstop for OpenAI's 10 GW Piketon campus
- **V1 (the "Lucent redux" take):** guarantee / guarantor revenue = 116% (278% incl. the discussed $350B chip financing) vs Lucent 24%, Nortel 10%, Cisco 11% at the 2000 peak — 5x the worst telecom vendor-financing intensity.
- **V2:** prices the guarantee as a contingency. Full-build lease ≈ $58B/yr needs ~$195B of OpenAI revenue; monetization paths reused from the existing AI capital-cycle model cover it in 2030 (fast), 2031 (central), never by 2035 (slow). Expected loss ≈ $25B ≈ 25% of one year of Nvidia FCF with wrong-way GPU collateral; worst case ≈ 2.1 years of FCF. Earnings/circularity risk (70% of project capex is the guarantor's own chips), not Lucent-style solvency risk.

## 2. $130B of data centers blocked or delayed vs the BNEF 194 GW-by-2035 path
- **V1:** $130B ÷ $11B/GW annualized = 47 GW/yr blocked > 15.9 GW/yr required → "forecast infeasible."
- **V2:** fixes capex semantics (3.7–11.8 GW depending on whether announced value includes IT gear), phantom-queue realization (~40%), and relocation (~60%); net consent drag is 1.4–4.5 GW/yr of average load — comparable to the 1.5–5.3 GW/yr firm-capacity drag computed with the existing `data-center-grid` model. Both channels delay rather than derail; the "power shortage" attribution of the $130B is a misread (Data Center Watch attributes it to local consent).

## 3. Solar generated more US electricity than coal in May 2026 — first month ever
- **V1:** reads the monthly milestone as the annual crossover ("solar overtook coal in 2026").
- **V2:** May seasonal factors (solar 1.20x, coal 0.84x) derived from 2025 anchors reproduce the observed May 2026 values within 6–8% one year ahead; annual crossover lands 2028 (2028–2030 under sensitivities), with a ~190 TWh annual solar deficit still in 2026. Tie-in: the baseline world model puts the same global crossover at ~2034.

## Simplify pass (second commit)
Applied a 4-angle cleanup review: reuse (`capitalRecoveryFactor`, `validateShares`, BNEF anchors inherited from `dataCenterGridEvidence`), year-axis alignment with the AI capital-cycle model, peak→average-load conversion derived from the grid run's own outputs, judgment thresholds promoted to case fields, and dead case fields removed or put to work.

## Validation
- `npm test`: all suites pass (0 failures)
- `npm run regression`: 7 scenarios, all metrics within tolerance
- New tests in `src/simulations/news/headline-experiments-2026-07-27.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfUr2vvV9YrGQPHgyBuWmF